### PR TITLE
Move "PAUSE" sprite away to a less intrusive location

### DIFF
--- a/main.asm
+++ b/main.asm
@@ -4965,9 +4965,9 @@ gameModeState_startButtonHandling:
         ldy #$02
         jsr memset_page
 @pauseLoop:
-        lda #$74
+        lda #$C5
         sta spriteXOffset
-        lda #$58
+        lda #$16
         sta spriteYOffset
         ; put 3 or 5 in a
         lda debugFlag

--- a/main.asm
+++ b/main.asm
@@ -2597,13 +2597,13 @@ sprite01GameTypeCursor:
 sprite02Blank:
         .byte   $00,$FF,$00,$00,$FF
 sprite03PausePalette6:
-        .byte   $00,$19,$00,$00,$00,$0A,$00,$08
-        .byte   $00,$1E,$00,$10,$00,$1C,$00,$18
-        .byte   $00,$0E,$00,$20,$FF
+        .byte   $00,'P',$00,$00,$00,'A',$00,$08
+        .byte   $00,'U',$00,$10,$00,'S',$00,$18
+        .byte   $00,'E',$00,$20,$FF
 sprite05DebugPalette4:
-        .byte   $00,$0b,$00,$00,$00,$15,$00,$08
-        .byte   $00,$18,$00,$10,$00,$0c,$00,$18
-        .byte   $00,$14,$00,$20
+        .byte   $00,'B',$00,$00,$00,'L',$00,$08
+        .byte   $00,'O',$00,$10,$00,'C',$00,$18
+        .byte   $00,'K',$00,$20
         .byte   $FF
 sprite06TPiece:
         .byte   $00,$7B,$02,$FC,$00,$7B,$02,$04
@@ -2636,24 +2636,24 @@ sprite0CIPiece:
 sprite0EHighScoreNameCursor:
         .byte   $00,$FD,$20,$00,$FF
 spriteDebugLevelEdit:
-        .byte   $00,$21,$00,$00
+        .byte   $00,'X',$00,$00
         .byte   $FF
 spriteStateLoad:
-        .byte   $00,$15,$03,$00,$00,$18,$03,$08
-        .byte   $00,$0A,$03,$10,$00,$0D,$03,$18
-        .byte   $00,$0E,$03,$20,$00,$0D,$03,$28
+        .byte   $00,'L',$03,$00,$00,'O',$03,$08
+        .byte   $00,'A',$03,$10,$00,'D',$03,$18
+        .byte   $00,'E',$03,$20,$00,'D',$03,$28
         .byte   $FF
 spriteStateSave:
-        .byte   $00,$1c,$03,$00,$00,$0a,$03,$08
-        .byte   $00,$1f,$03,$10,$00,$0e,$03,$18
-        .byte   $00,$0d,$03,$20
+        .byte   $00,'S',$03,$00,$00,'A',$03,$08
+        .byte   $00,'V',$03,$10,$00,'E',$03,$18
+        .byte   $00,'D',$03,$20
         .byte   $FF
 spriteOff:
-        .byte   $00,$18,$00,$00,$00,$0f,$00,$08
-        .byte   $00,$0f,$00,$10
+        .byte   $00,'O',$00,$00,$00,'F',$00,$08
+        .byte   $00,'F',$00,$10
         .byte   $FF
 spriteOn:
-        .byte   $00,$18,$00,$08,$00,$17,$00,$10
+        .byte   $00,'O',$00,$08,$00,'N',$00,$10
         .byte   $FF
 spriteSeedCursor:
         .byte   $00,$6B,$00,$00


### PR DESCRIPTION
## Context

Pause being set above the field is a little distracting, and it can get in the way of systems doing visual inspection of frames, like nestrischamps.

![image](https://user-images.githubusercontent.com/935223/133889543-9e255681-a750-4791-9a42-1257ef22c78f.png)

The same problem occured for the [das trainer rom](https://www.romhacking.net/hacks/3761/) which also doesn't blank the board on pause. Das Trainer Author JazzThief81 solved that by moving the sprite `PAUSE` to the score box, above the label `TOP`.

![image](https://user-images.githubusercontent.com/935223/133889216-7a67d321-6bd6-4e82-b542-f914605b6a37.png)

I believe there are no play modes in TetrisGym where the location is conflicting with something else, so this PR does the same change for TetrisGym.

If I am mistaken, or if you had plan to use the location for something else, let me know.

## Approach

* Change the pause sprite location to appear in the score box.

![image](https://user-images.githubusercontent.com/935223/133889337-85289fd3-a558-489b-839d-3d3e26364016.png)

Note that the location change also affects the `block` mode.

![image](https://user-images.githubusercontent.com/935223/133890132-d3d465dd-4119-46e2-bec9-e5ded9699169.png)

Additionally, when I was going through the code, I initially got lost trying to find the characters for `PAUSE`, before I realized they were encoded as their mapped value. I thought it would have helped me to see the characters in the bytearrays, so I added them for readability.

I'm no assembly expert though, so I don't know if this is bad practice, I can remove the first commit if you prefer, such that this PR is only shifting the sprite location.
