### PR TITLE
Restore standard pause in qual mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [v4 classic]
+- Standard pause in Qual Mode
+
 
 ## [v4]
 - B-Type Trainer (height 0-8)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 ## [v4 classic]
-- Standard pause in Qual Mode
-
+- Standard Pause in Qual Mode
+- No Next Box allowed in Qual Mode
 
 ## [v4]
 - B-Type Trainer (height 0-8)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## [v4 classic]
 - Standard Pause in Qual Mode
 - No Next Box allowed in Qual Mode
+- Block Tool cannot be used in Qual Mode
 
 ## [v4]
 - B-Type Trainer (height 0-8)

--- a/README.md
+++ b/README.md
@@ -269,6 +269,8 @@ Also reintroduces other classic features like the end game curtain, standard pau
 
 These features make TetrisGYM work better with post processing tools like [NestrisChamps](https://github.com/timotheeg/nestrischamps) and [MaxoutClub](https://maxoutclub.com/).
 
+You cannot use the Block Tool and Qual mode at the same time.
+
 ## PAL Mode
 
 Dictate if the NTSC or PAL gameplay mechanics should be used. Should automatically detect region, but can be manually overwritten otherwise.

--- a/README.md
+++ b/README.md
@@ -265,6 +265,9 @@ Combined with the level editor, savestates are effective for practising specific
 
 Reintroduces the 'wait screens', intended for use in qualifiers where the the player would otherwise gain a time advantage skipping the rocket, legal and title screens.
 
+Qual mode additionally reintroduces the end-game curtain, and the black-screen pause. With that, qual mode makes TetrisGYM friendly to post processor tools like [NestrisChamps](https://github.com/timotheeg/nestrischamps), which are otherwise not able to determine game over events, and are confused by the pause text which they interpret as blocks on the field.
+
+
 ## PAL Mode
 
 Dictate if the NTSC or PAL gameplay mechanics should be used. Should automatically detect region, but can be manually overwritten otherwise.

--- a/README.md
+++ b/README.md
@@ -265,8 +265,9 @@ Combined with the level editor, savestates are effective for practising specific
 
 Reintroduces the 'wait screens', intended for use in qualifiers where the the player would otherwise gain a time advantage skipping the rocket, legal and title screens.
 
-Qual mode additionally reintroduces the end-game curtain, and the black-screen pause. With that, qual mode makes TetrisGYM friendly to post processor tools like [NestrisChamps](https://github.com/timotheeg/nestrischamps), which are otherwise not able to determine game over events, and are confused by the pause text which they interpret as blocks on the field.
+Also reintroduces other classic features like the end game curtain, standard pause, and no next box.
 
+These features make TetrisGYM work better with post processing tools like [NestrisChamps](https://github.com/timotheeg/nestrischamps) and [MaxoutClub](https://maxoutclub.com/).
 
 ## PAL Mode
 

--- a/main.asm
+++ b/main.asm
@@ -9,7 +9,6 @@
 
 PRACTISE_MODE := 1
 NO_MUSIC := 1
-ALWAYS_NEXT_BOX := 1
 AUTO_WIN := 0
 NO_SCORING := 0
 DEV_MODE := 0
@@ -2392,10 +2391,12 @@ orientationTable:
         .byte   $FF,$00,$00,$FF,$00,$00,$FF,$00
 
 stageSpriteForNextPiece:
-.if !ALWAYS_NEXT_BOX
+        lda qualFlag
+        beq @alwaysNextBox
         lda displayNextPiece
         bne @ret
-.endif
+
+@alwaysNextBox:
         lda #$C8
         sta spriteXOffset
         lda #$77

--- a/main.asm
+++ b/main.asm
@@ -4960,23 +4960,21 @@ pause:
         sta musicStagingNoiseHi
 
         lda qualFlag
-        beq @pauseSetupNotQual
+        beq @pauseSetupNotClassic
 
-@pauseSetupQual:
+@pauseSetupClassic:
         lda #$00
         sta renderMode
-        jsr updateAudioAndWaitForNmi
         lda #$16
+        sta PPUMASK
         jmp @pauseSetupPart2
 
-@pauseSetupNotQual:
+@pauseSetupNotClassic:
         lda #$04 ; render_mode_pause
         sta renderMode
-        jsr updateAudioAndWaitForNmi
-        lda #$1E ; $16 for black
 
 @pauseSetupPart2:
-        sta PPUMASK
+        jsr updateAudioAndWaitForNmi
         lda #$FF
         ldx #$02
         ldy #$02
@@ -4984,16 +4982,16 @@ pause:
 
 @pauseLoop:
         lda qualFlag
-        beq @pauseLoopNotQual
+        beq @pauseLoopNotClassic
 
-@pauseLoopQual:
+@pauseLoopClassic:
         lda #$70
         sta spriteXOffset
         lda #$77
         sta spriteYOffset
         jmp @pauseLoopCommon
 
-@pauseLoopNotQual:
+@pauseLoopNotClassic:
         lda #$74
         sta spriteXOffset
         lda #$58

--- a/main.asm
+++ b/main.asm
@@ -1046,7 +1046,7 @@ menuConfigControls:
         dec menuVars, x
         lda #$01
         sta soundEffectSlot1Init
-        jsr checkGoofy
+        jsr assertValues
 @skipLeftConfig:
 
         ; check if pressing right
@@ -1060,7 +1060,7 @@ menuConfigControls:
         inc menuVars, x
         lda #$01
         sta soundEffectSlot1Init
-        jsr checkGoofy
+        jsr assertValues
 @skipRightConfig:
 @configEnd:
         rts
@@ -1068,7 +1068,25 @@ menuConfigControls:
 menuConfigSizeLookup:
         .byte   MENUSIZES
 
-checkGoofy:
+assertValues:
+        ; make sure you can only have block or qual
+        lda practiseType
+        cmp #MODE_QUAL
+        bne @noQual
+        lda menuVars, x
+        beq @noQual
+        lda #0
+        sta debugFlag
+@noQual:
+        lda practiseType
+        cmp #MODE_DEBUG
+        bne @noDebug
+        lda menuVars, x
+        beq @noDebug
+        lda #0
+        sta qualFlag
+@noDebug:
+        ; goofy
         lda practiseType
         cmp #MODE_GOOFY
         bne @noFlip


### PR DESCRIPTION
## Context

In [qual mode](https://github.com/kirjavascript/TetrisGYM#qual-mode), wait screens are restored and not skipped, and curtain is restored too.

Re-adding the curtain was a restoration for timing sakes, but it also helped with post-processor tools like [NestrisChamps](https://github.com/timotheeg/nestrischamps) which, when curtain is not present, can not detect the game-over event reliably.

In this PR, the Classic Tetris pause screen is also restored. With the way TetrisGYM was overlaying the characters `PAUSE` on the field, post-processing tools would incorrectly detect the characters as blocks in the field.

## Approach

1. Restore black-screen pause from Classic Tetris (including repositioning the pause text to match)
2. Update readme file to add these details

With a black screen, the block mode is not useful, and so the subroutine call `practiseGameHUD` is also skipped.

Tested on OSX with openEmu 2.3.3
