### PR TITLE
Famicom keyboard

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,14 @@
 #!/bin/sh
 
+while getopts 'm:kv' flag; do
+  case "${flag}" in
+    m) ines_mapper=${OPTARG} ;;
+    k) keyboard_arg='-D KEYBOARD' ;;
+    v) set -x ;;
+    *) error "Unexpected option ${flag}" ;;
+  esac
+done
+
 # build / compress nametables
 
 node src/nametables/build.js
@@ -38,8 +47,8 @@ touch "$0"
 
 # build object files
 
-ca65 -D INES_MAPPER="${1:-1}" -g src/header.asm -o header.o
-ca65 -D INES_MAPPER="${1:-1}" -l tetris.lst -g src/main.asm -o main.o
+ca65 -D INES_MAPPER="${ines_mapper:-1}" $keyboard_arg -g src/header.asm -o header.o
+ca65 -D INES_MAPPER="${ines_mapper:-1}" $keyboard_arg -l tetris.lst -g src/main.asm -o main.o
 
 # link object files
 

--- a/build.sh
+++ b/build.sh
@@ -1,11 +1,46 @@
 #!/bin/sh
 
-while getopts 'm:kv' flag; do
+compile_flags=()
+
+help () {
+    echo "Usage: $0 [-v] [-m <1|3>] [-a] [-s] [-k] [-h]"
+    echo "-v  Enable verbose output"  
+    echo "-m  Set mapper.  Valid values are 1 and 3.  Default 1." 
+    echo "-a  Enable pressing select to end game" 
+    echo "-s  Disable saving of high scores" 
+    echo "-k  Enable Famicom Keyboard support" 
+    echo "-h  Print this help and exit" 
+}
+
+while getopts "vm:askh" flag; do
   case "${flag}" in
-    m) ines_mapper=${OPTARG} ;;
-    k) keyboard_arg='-D KEYBOARD' ;;
     v) set -x ;;
-    *) error "Unexpected option ${flag}" ;;
+    
+    m)  
+        if ! [[ "${OPTARG}" =~ ^[13]$ ]]; then
+            echo "Valid INES_MAPPER (-m) options are 1 or 3"
+            exit 1
+        fi
+        compile_flags+=("-D INES_MAPPER=${OPTARG}")
+        echo "INES_MAPPER set to ${OPTARG}"  ;;
+ 
+    a) 
+        compile_flags+=("-D AUTO_WIN_ENABLE")
+        echo "AUTO_WIN enabled"  ;;
+
+    s) 
+        compile_flags+=("-D SAVE_HIGHSCORES_DISABLE")
+        echo "SAVE_HIGHSCORES disabled"  ;;
+
+    k) 
+        compile_flags+=("-D KEYBOARD_ENABLE")
+        echo "KEYBOARD enabled"  ;;
+
+    h) 
+        help; exit ;;
+
+    *) 
+        help; exit 1 ;;
   esac
 done
 
@@ -47,8 +82,8 @@ touch "$0"
 
 # build object files
 
-ca65 -D INES_MAPPER="${ines_mapper:-1}" $keyboard_arg -g src/header.asm -o header.o
-ca65 -D INES_MAPPER="${ines_mapper:-1}" $keyboard_arg -l tetris.lst -g src/main.asm -o main.o
+ca65 ${compile_flags[*]} -g src/header.asm -o header.o
+ca65 ${compile_flags[*]} -l tetris.lst -g src/main.asm -o main.o
 
 # link object files
 

--- a/src/constants.asm
+++ b/src/constants.asm
@@ -92,10 +92,13 @@ MENU_SPRITE_Y_BASE := $47
 MENU_MAX_Y_SCROLL := $70
 MENU_TOP_MARGIN_SCROLL := 7 ; in blocks
 
+; Used by Family Basic Keyboard
+.ifdef KEYBOARD
 KB_INIT := $05
 KB_COL_0 := $04
 KB_COL_1 := $06
 KB_MASK  := $1E
+.endif
 
 ; menuConfigSizeLookup
 ; menu ram is defined at menuRAM in ./ram.asm

--- a/src/constants.asm
+++ b/src/constants.asm
@@ -2,11 +2,27 @@
 INES_MAPPER := 1 ; supports 1 and 3 (MMC1 / CNROM)
 .endif
 
-NO_MUSIC := 1
+.ifdef SAVE_HIGHSCORES_DISABLE
+SAVE_HIGHSCORES := 0
+.else
 SAVE_HIGHSCORES := 1
+.endif
+
+.ifdef AUTO_WIN_ENABLE
+AUTO_WIN := 1  ; press select to end game
+.else
+AUTO_WIN := 0
+.endif
+
+.ifdef KEYBOARD_ENABLE
+KEYBOARD := 1
+.else
+KEYBOARD := 0
+.endif
+
+NO_MUSIC := 1
 
 ; dev flags
-AUTO_WIN := 0 ; press select to end game
 NO_SCORING := 0 ; breaks pace
 NO_SFX := 0
 NO_MENU := 0

--- a/src/constants.asm
+++ b/src/constants.asm
@@ -92,6 +92,11 @@ MENU_SPRITE_Y_BASE := $47
 MENU_MAX_Y_SCROLL := $70
 MENU_TOP_MARGIN_SCROLL := 7 ; in blocks
 
+KB_INIT := $05
+KB_COL_0 := $04
+KB_COL_1 := $06
+KB_MASK  := $1E
+
 ; menuConfigSizeLookup
 ; menu ram is defined at menuRAM in ./ram.asm
 .define MENUSIZES $0, $0, $0, $0, $F, $7, $8, $C, $20, $10, $1F, $8, $4, $12, $10, $0, $0, $0, $0, $4, $1, $1, $1, $1, $1, $1, $1, $1, $1, $1

--- a/src/constants.asm
+++ b/src/constants.asm
@@ -92,14 +92,6 @@ MENU_SPRITE_Y_BASE := $47
 MENU_MAX_Y_SCROLL := $70
 MENU_TOP_MARGIN_SCROLL := 7 ; in blocks
 
-; Used by Family Basic Keyboard
-.ifdef KEYBOARD
-KB_INIT := $05
-KB_COL_0 := $04
-KB_COL_1 := $06
-KB_MASK  := $1E
-.endif
-
 ; menuConfigSizeLookup
 ; menu ram is defined at menuRAM in ./ram.asm
 .define MENUSIZES $0, $0, $0, $0, $F, $7, $8, $C, $20, $10, $1F, $8, $4, $12, $10, $0, $0, $0, $0, $4, $1, $1, $1, $1, $1, $1, $1, $1, $1, $1

--- a/src/io.asm
+++ b/src/io.asm
@@ -35,7 +35,7 @@ JOY1        := $4016
 JOY2_APUFC  := $4017                        ; read: bits 0-4 joy data lines (bit 0 being normal controller), bits 6-7 are FC inhibit and mode
 
 ; Used by Family Basic Keyboard
-.ifdef KEYBOARD
+.if KEYBOARD
 KB_INIT := $05
 KB_COL_0 := $04
 KB_COL_1 := $06

--- a/src/io.asm
+++ b/src/io.asm
@@ -34,6 +34,14 @@ SND_CHN     := $4015
 JOY1        := $4016
 JOY2_APUFC  := $4017                        ; read: bits 0-4 joy data lines (bit 0 being normal controller), bits 6-7 are FC inhibit and mode
 
+; Used by Family Basic Keyboard
+.ifdef KEYBOARD
+KB_INIT := $05
+KB_COL_0 := $04
+KB_COL_1 := $06
+KB_MASK  := $1E
+.endif
+
 MMC1_Control := $8000
 MMC1_CHR0   := $BFFF
 MMC1_CHR1   := $DFFF

--- a/src/main.asm
+++ b/src/main.asm
@@ -30,6 +30,7 @@ mainLoop:
 .include "nmi/nmi.asm"
 .include "nmi/render.asm"
 .include "nmi/pollcontroller.asm"
+.include "nmi/pollkeyboard.asm"
 
 .include "gamemode/branch.asm"
     ; -> playAndEnding

--- a/src/main.asm
+++ b/src/main.asm
@@ -30,7 +30,7 @@ mainLoop:
 .include "nmi/nmi.asm"
 .include "nmi/render.asm"
 .include "nmi/pollcontroller.asm"
-.ifdef KEYBOARD
+.if KEYBOARD
 ; Code used to read Family BASIC Keyboard
 .include "nmi/pollkeyboard.asm"
 .endif

--- a/src/main.asm
+++ b/src/main.asm
@@ -30,8 +30,11 @@ mainLoop:
 .include "nmi/nmi.asm"
 .include "nmi/render.asm"
 .include "nmi/pollcontroller.asm"
-.include "nmi/pollkeyboard.asm"
 
+.ifdef KEYBOARD
+; Code used to read Family BASIC Keyboard
+.include "nmi/pollkeyboard.asm"
+.endif
 .include "gamemode/branch.asm"
     ; -> playAndEnding
 .include "gamemodestate/branch.asm"

--- a/src/main.asm
+++ b/src/main.asm
@@ -30,11 +30,11 @@ mainLoop:
 .include "nmi/nmi.asm"
 .include "nmi/render.asm"
 .include "nmi/pollcontroller.asm"
-
 .ifdef KEYBOARD
 ; Code used to read Family BASIC Keyboard
 .include "nmi/pollkeyboard.asm"
 .endif
+
 .include "gamemode/branch.asm"
     ; -> playAndEnding
 .include "gamemodestate/branch.asm"

--- a/src/nmi/nmi.asm
+++ b/src/nmi/nmi.asm
@@ -27,7 +27,7 @@ nmi:    pha
         lda #$01
         sta verticalBlankingInterval
         jsr pollControllerButtons
-.ifdef KEYBOARD
+.if KEYBOARD
 ; Read Family BASIC Keyboard
         jsr pollKeyboard
 .endif

--- a/src/nmi/nmi.asm
+++ b/src/nmi/nmi.asm
@@ -27,7 +27,10 @@ nmi:    pha
         lda #$01
         sta verticalBlankingInterval
         jsr pollControllerButtons
+.ifdef KEYBOARD
+; Read Family BASIC Keyboard
         jsr pollKeyboard
+.endif
         pla
         tay
         pla

--- a/src/nmi/nmi.asm
+++ b/src/nmi/nmi.asm
@@ -27,6 +27,7 @@ nmi:    pha
         lda #$01
         sta verticalBlankingInterval
         jsr pollControllerButtons
+        jsr pollKeyboard
         pla
         tay
         pla

--- a/src/nmi/pollkeyboard.asm
+++ b/src/nmi/pollkeyboard.asm
@@ -93,6 +93,7 @@ pollKeyboard:
         lda newlyPressedKeys
         ora #BUTTON_UP
         sta newlyPressedKeys
+        bne @skipDownRead
 @upNotPressed:
 
         ldy #$08
@@ -102,6 +103,7 @@ pollKeyboard:
         lda newlyPressedKeys
         ora #BUTTON_DOWN
         sta newlyPressedKeys
+@skipDownRead:
 @downNotPressed:
 
         ldy #$08
@@ -111,6 +113,7 @@ pollKeyboard:
         lda newlyPressedKeys
         ora #BUTTON_LEFT
         sta newlyPressedKeys
+        bne @skipRightRead
 @leftNotPressed:
 
         ldy #$08
@@ -120,6 +123,7 @@ pollKeyboard:
         lda newlyPressedKeys
         ora #BUTTON_RIGHT
         sta newlyPressedKeys
+@skipRightRead:
 @rightNotPressed: 
 
         ldy #$07     ; grph -> B

--- a/src/nmi/pollkeyboard.asm
+++ b/src/nmi/pollkeyboard.asm
@@ -67,11 +67,14 @@ pollKeyboard:
         asl
         ora keyboardInput,x
         eor #$FF
+        cmp #$FF
+        beq @ret   ; Assume 8 simultaneously pressed keys means there's no keyboard to be read
         sta keyboardInput,x
         inx
         cpx #$09
         bne @rowLoop
-
+        jsr mapKeysToButtons
+@ret:   rts
 
 ; Bit0  Bit1    Bit2    Bit3      Bit4    Bit5    Bit6     Bit7
 ; ] 	[ 	RETURN 	F8 	  STOP 	  ¥ 	  RSHIFT   KANA
@@ -86,6 +89,8 @@ pollKeyboard:
 
 ; Read keys.  up/down/left/right are mapped directly
 
+
+mapKeysToButtons:
         ldy #$08
         ldx #$02
         jsr readKey

--- a/src/nmi/pollkeyboard.asm
+++ b/src/nmi/pollkeyboard.asm
@@ -1,0 +1,72 @@
+; https://www.nesdev.org/wiki/Family_BASIC_Keyboard
+
+; Input ($4016 write)
+
+; 7  bit  0
+; ---- ----
+; xxxx xKCR
+;       |||
+;       ||+-- Reset the keyboard to the first row.
+;       |+--- Select column, row is incremented if this bit goes from high to low.
+;       +---- Enable keyboard matrix (if 0, all voltages inside the keyboard will be 5V, reading back as logical 0 always)
+
+; Incrementing the row from the (keyless) 10th row will cause it to wrap back to the first row. 
+
+; Output ($4017 read)
+
+; 7  bit  0
+; ---- ----
+; xxxK KKKx
+;    | |||
+;    +-+++--- Receive key status of currently selected row/column.
+
+; Any key that is held down, will read back as 0.
+
+; ($4016 reads from the data recorder.)
+
+; Similar to the Family Trainer Mat, there are parasitic capacitances that the program must wait for to get a valid result. Family
+; BASIC waits approximately 50 cycles after advancing rows before assuming the output is valid.
+; Usage
+
+; Family BASIC reads the keyboard state with the following procedure:
+
+;     Write $05 to $4016 (reset to row 0, column 0)
+;     Write $04 to $4016 (select column 0, next row if not just reset)
+;     Read column 0 data from $4017
+;     Write $06 to $4016 (select column 1)
+;     Read column 1 data from $4017
+;     Repeat steps 2-5 eight more times
+
+; Note that Family BASIC never writes to $4016 with bit 2 clear, there is no need to disable the keyboard matrix.
+
+
+pollKeyboard:
+        ldx #$00
+        lda #KB_INIT
+        sta JOY1
+@rowLoop:
+        lda #KB_COL_0
+        sta JOY1
+        ldy #$0A
+@avoidParasiticCapacitance:              ; wait approx 50 cycles after advancing rows
+        dey                 
+        bne @avoidParasiticCapacitance
+        lda JOY2_APUFC
+        and #KB_MASK
+        sta generalCounter
+        lda #KB_COL_1
+        sta JOY1
+        lda JOY2_APUFC      
+        and #KB_MASK
+        lsr
+        sta keyboardInput,x
+        lda generalCounter
+        asl
+        asl
+        asl
+        ora keyboardInput,x
+        sta keyboardInput,x
+        inx
+        cpx #$09
+        bne @rowLoop
+        rts

--- a/src/ram.asm
+++ b/src/ram.asm
@@ -208,14 +208,14 @@ linecapState: .res 1 ; $639 ; 0 if not triggered, 1 + linecapHow otherwise, rese
 
 dasOnlyShiftDisabled: .res 1 ; $63A
 
-.ifdef KEYBOARD
-; Reserve 11 bytes for Family BASIC Keyboard
     .res $3A
+
+.ifdef KEYBOARD
 newlyPressedKeys: .res 1 ; $0675
 heldKeys: .res 1 ; $0676
 keyboardInput: .res 9 ; $0677
 .else
-    .res $45
+    .res $B
 .endif
 
 musicStagingSq1Lo: .res 1 ; $0680

--- a/src/ram.asm
+++ b/src/ram.asm
@@ -210,7 +210,7 @@ dasOnlyShiftDisabled: .res 1 ; $63A
 
     .res $3A
 
-.ifdef KEYBOARD
+.if KEYBOARD
 newlyPressedKeys: .res 1 ; $0675
 heldKeys: .res 1 ; $0676
 keyboardInput: .res 9 ; $0677

--- a/src/ram.asm
+++ b/src/ram.asm
@@ -207,11 +207,17 @@ harddropBuffer: .res $14 ; $625 ; 20 bytes (!)
 linecapState: .res 1 ; $639 ; 0 if not triggered, 1 + linecapHow otherwise, reset on game init
 
 dasOnlyShiftDisabled: .res 1 ; $63A
-    .res $3A
 
+.ifdef KEYBOARD
+; Reserve 11 bytes for Family BASIC Keyboard
+    .res $3A
 newlyPressedKeys: .res 1 ; $0675
 heldKeys: .res 1 ; $0676
 keyboardInput: .res 9 ; $0677
+.else
+    .res $45
+.endif
+
 musicStagingSq1Lo: .res 1 ; $0680
 musicStagingSq1Hi: .res 1 ; $0681
 audioInitialized: .res 1 ; $0682

--- a/src/ram.asm
+++ b/src/ram.asm
@@ -207,8 +207,10 @@ harddropBuffer: .res $14 ; $625 ; 20 bytes (!)
 linecapState: .res 1 ; $639 ; 0 if not triggered, 1 + linecapHow otherwise, reset on game init
 
 dasOnlyShiftDisabled: .res 1 ; $63A
-    .res $3C
-    
+    .res $3A
+
+newlyPressedKeys: .res 1 ; $0675
+heldKeys: .res 1 ; $0676
 keyboardInput: .res 9 ; $0677
 musicStagingSq1Lo: .res 1 ; $0680
 musicStagingSq1Hi: .res 1 ; $0681

--- a/src/ram.asm
+++ b/src/ram.asm
@@ -207,7 +207,9 @@ harddropBuffer: .res $14 ; $625 ; 20 bytes (!)
 linecapState: .res 1 ; $639 ; 0 if not triggered, 1 + linecapHow otherwise, reset on game init
 
 dasOnlyShiftDisabled: .res 1 ; $63A
-    .res $45
+    .res $3C
+    
+keyboardInput: .res 9 ; $0677
 musicStagingSq1Lo: .res 1 ; $0680
 musicStagingSq1Hi: .res 1 ; $0681
 audioInitialized: .res 1 ; $0682


### PR DESCRIPTION
Added code to read Family BASIC Keyboard and map to button input.  

The 72 keys are mapped to 9 consecutive bytes at $0677

Arrow keys are mapped to D-PAD buttons.  
Return is mapped to Start. 
Right shift is mapped to Select.  
Grph is mapped to B.  
Space is mapped to A.  

The mapped keys are stored in newlyPressedKeys and heldKeys and are then copied to newlyPressedButtons_player1 and heldButtons_player1 respectively.  

All keyboard code is compiled based on KEYBOARD flag.  Modified build.sh script to use args, with the arg -m option used to set mapper.  -k sets KEYBOARD flag, and -v sets the -x flag so full command output is shown.  

resolves #31 
