### PR TITLE
Safer debug mode

### DIFF
--- a/src/gamemodestate/pause.asm
+++ b/src/gamemodestate/pause.asm
@@ -96,18 +96,10 @@ pause:
         lda newlyPressedButtons_player1
         cmp #$10
         beq @resume
-@stayPaused:
         jsr updateAudioWaitForNmiAndResetOamStaging
         jmp @pauseLoop
 
 @resume:
-        ; Stay paused if invalid debug position
-        lda debugFlag
-        beq @validPosition
-        jsr isPositionValid
-        beq @validPosition
-        jmp @stayPaused     
-@validPosition:
         lda #$1E
         sta PPUMASK
         lda #$00

--- a/src/gamemodestate/pause.asm
+++ b/src/gamemodestate/pause.asm
@@ -96,10 +96,18 @@ pause:
         lda newlyPressedButtons_player1
         cmp #$10
         beq @resume
+@stayPaused:
         jsr updateAudioWaitForNmiAndResetOamStaging
         jmp @pauseLoop
 
 @resume:
+        ; Stay paused if invalid debug position
+        lda debugFlag
+        beq @validPosition
+        jsr isPositionValid
+        beq @validPosition
+        jmp @stayPaused     
+@validPosition:
         lda #$1E
         sta PPUMASK
         lda #$00

--- a/src/modes/debug.asm
+++ b/src/modes/debug.asm
@@ -39,11 +39,6 @@ debugSelectMenuControls:
         lda debugLevelEdit
         eor #1
         sta debugLevelEdit
-        ; Don't switch if invalid position
-        bne @skipDebugType
-        jsr isPositionValid
-        beq @skipDebugType
-        inc debugLevelEdit
 @skipDebugType:
 
         jsr checkSaveStateControlsDebug
@@ -113,37 +108,21 @@ debugContinue:
         jsr menuThrottle
         beq @notPressedUp
         dec tetriminoY
-        bpl @notPressedUp
-        lda #$13
-        sta tetriminoY
 @notPressedUp:
         lda #BUTTON_DOWN
         jsr menuThrottle
         beq @notPressedDown
         inc tetriminoY
-        lda tetriminoY
-        cmp #$14
-        bne @notPressedDown
-        lda #$00
-        sta tetriminoY
 @notPressedDown:
         lda #BUTTON_LEFT
         jsr menuThrottle
         beq @notPressedLeft
         dec tetriminoX
-        bpl @notPressedLeft
-        lda #$09
-        sta tetriminoX
 @notPressedLeft:
         lda #BUTTON_RIGHT
         jsr menuThrottle
         beq @notPressedRight
         inc tetriminoX
-        lda tetriminoX
-        cmp #$0A
-        bne @notPressedRight
-        lda #$00
-        sta tetriminoX
 @notPressedRight:
 
         ; check mode
@@ -170,8 +149,8 @@ debugContinue:
 @notPressedBothA:
 
         ; change current piece
-        lda newlyPressedButtons_player1
-        and #BUTTON_B
+        lda #BUTTON_B
+        jsr menuThrottle
         beq @notPressedB
         dec currentPiece
         bpl @notPressedB
@@ -179,8 +158,8 @@ debugContinue:
         sta currentPiece
 @notPressedB:
 
-        lda newlyPressedButtons_player1
-        and #BUTTON_A
+        lda #BUTTON_A
+        jsr menuThrottle
         beq @notPressedA
         inc currentPiece
         lda currentPiece

--- a/src/modes/debug.asm
+++ b/src/modes/debug.asm
@@ -39,6 +39,11 @@ debugSelectMenuControls:
         lda debugLevelEdit
         eor #1
         sta debugLevelEdit
+        ; Don't switch if invalid position
+        bne @skipDebugType
+        jsr isPositionValid
+        beq @skipDebugType
+        inc debugLevelEdit
 @skipDebugType:
 
         jsr checkSaveStateControlsDebug
@@ -108,21 +113,37 @@ debugContinue:
         jsr menuThrottle
         beq @notPressedUp
         dec tetriminoY
+        bpl @notPressedUp
+        lda #$13
+        sta tetriminoY
 @notPressedUp:
         lda #BUTTON_DOWN
         jsr menuThrottle
         beq @notPressedDown
         inc tetriminoY
+        lda tetriminoY
+        cmp #$14
+        bne @notPressedDown
+        lda #$00
+        sta tetriminoY
 @notPressedDown:
         lda #BUTTON_LEFT
         jsr menuThrottle
         beq @notPressedLeft
         dec tetriminoX
+        bpl @notPressedLeft
+        lda #$09
+        sta tetriminoX
 @notPressedLeft:
         lda #BUTTON_RIGHT
         jsr menuThrottle
         beq @notPressedRight
         inc tetriminoX
+        lda tetriminoX
+        cmp #$0A
+        bne @notPressedRight
+        lda #$00
+        sta tetriminoX
 @notPressedRight:
 
         ; check mode
@@ -152,19 +173,21 @@ debugContinue:
         lda newlyPressedButtons_player1
         and #BUTTON_B
         beq @notPressedB
-        lda currentPiece
-        cmp #$1
-        bmi @notPressedB
         dec currentPiece
+        bpl @notPressedB
+        lda #$12
+        sta currentPiece
 @notPressedB:
 
         lda newlyPressedButtons_player1
         and #BUTTON_A
         beq @notPressedA
-        lda currentPiece
-        cmp #$12
-        bpl @notPressedA
         inc currentPiece
+        lda currentPiece
+        cmp #$13
+        bne @notPressedA
+        lda #$00
+        sta currentPiece
 @notPressedA:
 
         ; handle piece


### PR DESCRIPTION
Another for your consideration.  I noticed that debug mode was easy to instantly end a game if you unpaused in the wrong position, so I dug into the code and made tweaks.  

Here's the changes:

Prevent unpausing if position is invalid.
Prevent switching from tile placer (not sure what to call it) if position is invalid.
TetriminoX and TetriminoY are now constrained to the playfield when using tile placer, looping from side to side or between top & bottom.  
Piece selection cycles from longbar to T or T to longbar instead of stopping.