### PR TITLE
switch to bank 0 for legal screen

### DIFF
--- a/src/gamemode/waitscreen.asm
+++ b/src/gamemode/waitscreen.asm
@@ -12,6 +12,9 @@ waitScreenLoad:
         lda #$02
         jsr changeCHRBank1
 .elseif INES_MAPPER = 3
+CNROM_CHR_LEGAL:
+        lda #0
+        sta CNROM_CHR_LEGAL+1
         lda #%10000000
         sta PPUCTRL
         sta currentPpuCtrl


### PR DESCRIPTION
Use bank0 during legal screen.  Unnoticeable unless additional tiles are being used from the rocket screen nametable.  