### PR TITLE
Fix legal->title flicker when cnrom

### DIFF
--- a/src/gamemode/waitscreen.asm
+++ b/src/gamemode/waitscreen.asm
@@ -15,8 +15,6 @@ waitScreenLoad:
 CNROM_CHR_LEGAL:
         lda #0
         sta CNROM_CHR_LEGAL+1
-        lda #%10000000
-        sta PPUCTRL
         sta currentPpuCtrl
 .endif
 


### PR DESCRIPTION
This corrects a flicker when the CNROM version switched from the legal to the title screen.  This zeroes out currentPpuControl, with the important bits being the sprite & bg bits being zeroed out, with nothing being written to PPUCTRL.    The value of currentPpuControl gets written to PPUCTRLwith the NMI bit enabled in waitForVBlankAndEnableNmi.    