### PR TITLE
Move region code

### DIFF
--- a/src/io.asm
+++ b/src/io.asm
@@ -62,6 +62,6 @@ MMC5_CHR_BANK1 := $5127
 
 .macro RESET_MMC1
 .if INES_MAPPER = 1
-        inc $8000 ; initRam
+        inc $8000 ; checkRegion
 .endif
 .endmacro

--- a/src/main.asm
+++ b/src/main.asm
@@ -15,6 +15,9 @@
 
 .segment    "PRG_chunk1": absolute
 
+; region code at start of page to keep cycle count consistent
+.include "util/check_region.asm"
+
 initRam:
 
 .include "boot.asm"
@@ -46,7 +49,6 @@ mainLoop:
 .include "highscores/entry_screen.asm"
 
 .include "util/core.asm"
-.include "util/check_region.asm"
 .include "util/bytesprite.asm"
 .include "util/strings.asm"
 .include "util/math.asm"


### PR DESCRIPTION
Fixes #46 

This replaces the code at $8000 which was used for the MMC1 reset.  Previously it was ldy ($a0) and has been replaced with ldx ($a2).  Both of these values have a 1 in bit 7 which is the only bit that's significant for the reset.  https://www.nesdev.org/wiki/MMC1#Reset