### PR TITLE
No0001

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Block Tool pieces wrap around
 * Added hidden score option
 * Added marathon mode
+* 0001 seeds are ignored
 
 ## [v5 tournament]
 * Linecap Menu (from CTM Masters September 2022)

--- a/src/gamemode/gametypemenu/menu.asm
+++ b/src/gamemode/gametypemenu/menu.asm
@@ -101,7 +101,7 @@ gameTypeLoopCheckStart:
         lda set_seed_input
         bne @checkSelectable
         lda set_seed_input+1
-        and #$FE
+        and #$FE ; treat 0001 like 0000
         beq gameTypeLoopNext
 
 @checkSelectable:
@@ -415,7 +415,7 @@ renderMenuVars:
         lda set_seed_input
         bne @renderIndicator
         lda set_seed_input+1
-        and #$FE
+        and #$FE ; treat 0001 like 0000
         beq @cursorFinished
 @renderIndicator:
         ldx #$E

--- a/src/gamemode/gametypemenu/menu.asm
+++ b/src/gamemode/gametypemenu/menu.asm
@@ -101,6 +101,7 @@ gameTypeLoopCheckStart:
         lda set_seed_input
         bne @checkSelectable
         lda set_seed_input+1
+        and #$FE
         beq gameTypeLoopNext
 
 @checkSelectable:
@@ -414,6 +415,7 @@ renderMenuVars:
         lda set_seed_input
         bne @renderIndicator
         lda set_seed_input+1
+        and #$FE
         beq @cursorFinished
 @renderIndicator:
         ldx #$E


### PR DESCRIPTION
The RNG implementation tosses out the least significant bit from the 2nd byte making 0001 effectively the same as 0000.  By zeroing out that bit before branching on zero, then seeds beginning with 0001 are ignored.