### PR TITLE
independent mmc1 reset

### DIFF
--- a/src/io.asm
+++ b/src/io.asm
@@ -62,6 +62,7 @@ MMC5_CHR_BANK1 := $5127
 
 .macro RESET_MMC1
 .if INES_MAPPER = 1
-        inc $8000 ; checkRegion
+:       inc :-  ; increments inc ($aa), writing a negative value to prg
+                ; https://www.nesdev.org/wiki/MMC1#Reset
 .endif
 .endmacro


### PR DESCRIPTION
This eliminates the need for the code at $8000 to start with a particular opcode.  