### PR TITLE
Faster oam reset

### DIFF
--- a/src/gamemodestate/pause.asm
+++ b/src/gamemodestate/pause.asm
@@ -38,10 +38,7 @@ pause:
 
 @pauseSetupPart2:
         jsr updateAudioAndWaitForNmi
-        lda #$FF
-        ldx #$02
-        ldy #$02
-        jsr memset_page
+        jsr resetOAMStaging
 
 @pauseLoop:
         lda qualFlag

--- a/src/util/core.asm
+++ b/src/util/core.asm
@@ -50,6 +50,16 @@ random10:
         bpl random10
         rts
 
+; canon is waitForVerticalBlankingInterval
+updateAudioWaitForNmiAndResetOamStaging:
+        jsr updateAudio_jmp
+        lda #$00
+        sta verticalBlankingInterval
+        nop
+@checkForNmi:
+        lda verticalBlankingInterval
+        beq @checkForNmi
+
 resetOAMStaging:
 ; Hide a sprite by moving it down offscreen, by writing any values between #$EF-#$FF here. 
 ; Sprites are never displayed on the first line of the picture, and it is impossible to place 
@@ -66,18 +76,6 @@ resetOAMStaging:
         bne @hideY
         rts
 
-
-; canon is waitForVerticalBlankingInterval
-updateAudioWaitForNmiAndResetOamStaging:
-        jsr updateAudio_jmp
-        lda #$00
-        sta verticalBlankingInterval
-        nop
-@checkForNmi:
-        lda verticalBlankingInterval
-        beq @checkForNmi
-        jsr resetOAMStaging
-        rts
 
 updateAudioAndWaitForNmi:
         jsr updateAudio_jmp

--- a/src/util/core.asm
+++ b/src/util/core.asm
@@ -50,6 +50,23 @@ random10:
         bpl random10
         rts
 
+resetOAMStaging:
+; Hide a sprite by moving it down offscreen, by writing any values between #$EF-#$FF here. 
+; Sprites are never displayed on the first line of the picture, and it is impossible to place 
+; a sprite partially off the top of the screen. 
+; https://www.nesdev.org/wiki/PPU_OAM
+        ldx #$00
+        lda #$FF
+@hideY:
+        sta oamStaging,x
+        inx
+        inx
+        inx
+        inx
+        bne @hideY
+        rts
+
+
 ; canon is waitForVerticalBlankingInterval
 updateAudioWaitForNmiAndResetOamStaging:
         jsr updateAudio_jmp
@@ -59,10 +76,7 @@ updateAudioWaitForNmiAndResetOamStaging:
 @checkForNmi:
         lda verticalBlankingInterval
         beq @checkForNmi
-        lda #$FF
-        ldx #$02
-        ldy #$02
-        jsr memset_page
+        jsr resetOAMStaging
         rts
 
 updateAudioAndWaitForNmi:

--- a/src/util/core.asm
+++ b/src/util/core.asm
@@ -76,7 +76,6 @@ resetOAMStaging:
         bne @hideY
         rts
 
-
 updateAudioAndWaitForNmi:
         jsr updateAudio_jmp
         lda #$00


### PR DESCRIPTION
Reduces the clearing of OAM from 2872 cycles to 1047 by resetting only the y variable for each of the 64 sprite slots.  

This is related to a separate effort of sending data to nestrischamps via an everdrive.  The process to ship the data out currently takes 2100 cycles.  While currently I don't think that process is running past NMI, this looked like an easy opportunity to get some breathing room.  