### PR TITLE
Use zero flag and values left in accumulator

### DIFF
--- a/src/audio.asm
+++ b/src/audio.asm
@@ -566,7 +566,7 @@ soundEffectSlot1_rotateTetriminoPlaying:
 soundEffectSlot1_tetrisAchievedInit:
         lda #$05
         ldy palFlag
-        cpy #0
+        ; cpy #0 ; ldy sets z flag
         beq @ntsc
         lda #$4
 @ntsc:
@@ -584,7 +584,7 @@ LE417:  jmp initSoundEffectShared
 soundEffectSlot1_lineCompletedInit:
         lda #$05
         ldy palFlag
-        cpy #0
+        ; cpy #0 ; ldy sets z flag
         beq @ntsc
         lda #$4
 @ntsc:
@@ -600,7 +600,7 @@ soundEffectSlot1_lineCompletedPlaying:
 soundEffectSlot1_lineClearingInit:
         lda #$04
         ldy palFlag
-        cpy #0
+        ; cpy #0 ; ldy sets z flag
         beq @ntsc
         lda #$3
 @ntsc:
@@ -692,7 +692,7 @@ LE4E9:  jmp soundEffectSlot1Playing_stop
 soundEffectSlot1_levelUpInit:
         lda #$06
         ldy palFlag
-        cpy #0
+        ; cpy #0 ; ldy sets z flag
         beq @ntsc
         lda #$5
 @ntsc:
@@ -773,10 +773,16 @@ updateMusic_noSoundJmp:
 updateMusic:
         lda musicTrack
         tay
+        ; old:
+        ; cmp #$FF
+        ; beq updateMusic_noSoundJmp
+        ; cmp #$00
+        ; beq @checkIfAlreadyPlaying
+
+        ; new:
+        beq @checkIfAlreadyPlaying ; tay sets z flag
         cmp #$FF
         beq updateMusic_noSoundJmp
-        cmp #$00
-        beq @checkIfAlreadyPlaying
         sta currentAudioSlot
         sta musicTrack_dec
         dec musicTrack_dec
@@ -1127,7 +1133,7 @@ updateMusicFrame_progLoadRoutine:
         iny
         lda (musicChanTmpAddr),y
         sta musicDataChanPtrDeref+1,x
-        cmp #$00
+        ; cmp #$00 ; lda sets z flag
         beq updateMusicFrame_progEnd
         cmp #$FF
         beq updateMusicFrame_progLoadNextScript

--- a/src/boot.asm
+++ b/src/boot.asm
@@ -33,7 +33,7 @@
 @loop:
         dex
         sta menuRAM, x
-        cpx #0
+        ; cpx #0 ; dex sets z flag
         bne @loop
 
         ; default pace to A

--- a/src/gamemode/gametypemenu/menu.asm
+++ b/src/gamemode/gametypemenu/menu.asm
@@ -235,7 +235,7 @@ seedControls:
         clc
         tay
         and #$F
-        cmp #$0
+        ; cmp #$0 ; and sets z flag
         bne @noWrapDown
         tya
         and #$F0
@@ -284,7 +284,7 @@ menuConfigControls:
         beq @skipLeftConfig
         ; check if zero
         lda menuVars, x
-        cmp #0
+        ; cmp #0 ; lda sets z flag
         beq @skipLeftConfig
         ; dec value
         dec menuVars, x

--- a/src/gamemode/waitscreen.asm
+++ b/src/gamemode/waitscreen.asm
@@ -42,7 +42,7 @@ CNROM_CHR_LEGAL:
 
         lda #$FF
         ldx palFlag
-        cpx #0
+        ; cpx #0 ; ldx sets z flag
         beq @notPAL
         lda #$CC
 @notPAL:

--- a/src/gamemodestate/handlegameover.asm
+++ b/src/gamemodestate/handlegameover.asm
@@ -7,7 +7,7 @@ gameModeState_handleGameOver:
         lda #$05
         sta generalCounter2
         lda playState
-        cmp #$00
+        ; cmp #$00 ; lda sets z flag
         beq @gameOver
         jmp @ret
 @gameOver:

--- a/src/gamemodestate/initstate.asm
+++ b/src/gamemodestate/initstate.asm
@@ -300,7 +300,7 @@ L884A:
         lda #EMPTY_TILE
 L885D:  sta playfield,y
         dey
-        cpy #$0
+        ; cpy #$0 ; dey sets z flag
         bne L885D
         lda #$00
         sta vramRow

--- a/src/modes/debug.asm
+++ b/src/modes/debug.asm
@@ -3,7 +3,7 @@
 
 checkDebugGameplay:
         lda debugFlag
-        cmp #0
+        ; cmp #0 ; lda sets z flag
         beq @done
 
         ; sprite
@@ -91,7 +91,7 @@ DEBUG_ORIGINAL_Y := tmp1
 DEBUG_ORIGINAL_CURRENT_PIECE := tmp2
 
         lda debugFlag
-        cmp #0
+        ; cmp #0 ; lda sets z flag
         beq debugPauseDrawPieces
 
         jmp debugSelectMenuControls

--- a/src/modes/garbage.asm
+++ b/src/modes/garbage.asm
@@ -93,7 +93,7 @@ randomGarbage:
         bcc @done
 
         lda garbageDelay
-        cmp #0
+        ; cmp #0 ; lda sets z flag
         bne @delay
 
         jsr random10

--- a/src/modes/qtap.asm
+++ b/src/modes/qtap.asm
@@ -1,7 +1,7 @@
 advanceGameTap:
         jsr clearPlayfield
         ldx tapModifier
-        cpx #0
+        ; cpx #0 ; ldx sets z flag
         beq @skip ; skip if zero
         ldy #$BF ; left side
         cpx #$11

--- a/src/modes/tapqty.asm
+++ b/src/modes/tapqty.asm
@@ -14,7 +14,7 @@ prepareNextTapQuantity:
         lda tapqtyModifier
         and #$F
         tax
-        cpx #0
+        ; cpx #0 ; tax sets z flag
         bne @notZero
         ldx #4 ; default to four
 @notZero:

--- a/src/modes/tspins.asm
+++ b/src/modes/tspins.asm
@@ -65,7 +65,7 @@ advanceGameTSpins_actual:
 @notSuccessful:
         ; check if a tspin is setup
         lda tspinX
-        cmp #0
+        ; cmp #0 ; lda sets z flag
         bne renderTSpin
 
 generateNewTSpin:
@@ -117,7 +117,7 @@ renderTSpin:
         sta $03c7, x
         sta $03b3, x
         ldy tspinType
-        cpy #0
+        ; cpy #0 ; ldy sets z flag
         bne @noInc
         inx
         inx

--- a/src/nmi/render_mode_play_and_demo.asm
+++ b/src/nmi/render_mode_play_and_demo.asm
@@ -46,7 +46,7 @@ render_mode_play_and_demo:
         cmp #MODE_TYPEB
         beq @renderLevelTypeB
 
-        lda practiseType
+        ; lda practiseType ; accumulator is still practiseType
         cmp #MODE_CHECKERBOARD
         beq @renderLevelCheckerboard
 

--- a/src/nmi/render_score.asm
+++ b/src/nmi/render_score.asm
@@ -152,7 +152,8 @@ renderClassicHighByte:
         stx tmpX
         sty tmpY
 
-        cpx #0
+        ; cpx #0
+        txa ; either branch clobbers accumulator.  txa sets z, saves 1 byte.
         bne @startWrap
         lda tmpY ; score+2
         jsr twoDigsToPPU
@@ -206,7 +207,8 @@ renderLettersHighByte:
         stx tmpX
         sty tmpY
 
-        cpx #0
+        ; cpx #0
+        txa ; either branch clobbers accumulator.  txa sets z, saves 1 byte.
         bne @startWrap
         lda tmpY ; score+2
         jsr twoDigsToPPU

--- a/src/nmi/render_util.asm
+++ b/src/nmi/render_util.asm
@@ -21,7 +21,8 @@ renderByteBCDStart:
         sbc #100
         jmp @byte
 @not100:
-        cpx #0
+        ; cpx #0
+        txa ; either branch clobbers accumulator.  txa sets z, saves 1 byte.
         bne @main
         lda #$EF
         sta PPUDATA

--- a/src/playstate/active.asm
+++ b/src/playstate/active.asm
@@ -378,7 +378,7 @@ lookupDropSpeed:
         bcs @noTableLookup
         lda framesPerDropTableNTSC,x
         ldy palFlag
-        cpy #0
+        ; cpy #0 ; ldy sets z flag
         beq @noTableLookup
         lda framesPerDropTablePAL,x
 @noTableLookup:
@@ -433,7 +433,7 @@ shift_tetrimino:
         lda #$A
         sta dasValuePeriod
         ldy palFlag
-        cpy #0
+        ; cpy #0 ; ldy sets z flag
         beq @shiftTetrimino
         lda #$0C
         sta dasValueDelay

--- a/src/playstate/completedrows.asm
+++ b/src/playstate/completedrows.asm
@@ -33,7 +33,7 @@ playState_checkForCompletedRows:
         cmp #MODE_TSPINS
         beq @rowNotComplete
 
-        lda practiseType
+        ; lda practiseType ; accumulator is still practiseType
         cmp #MODE_FLOOR
         beq @floorCheck
         lda linecapState
@@ -112,7 +112,7 @@ playState_checkForCompletedRows:
         cmp #MODE_TAPQTY
         bne @tapQtyEnd
         lda completedLines
-        cmp #0
+        ; cmp #0 ; lda sets z flag
         beq @tapQtyEnd
         ; mark as complete
         lda tqtyNext

--- a/src/playstate/gameover_rocket.asm
+++ b/src/playstate/gameover_rocket.asm
@@ -47,7 +47,7 @@ playState_checkStartGameOver:
 
         lda #$80
         ldx palFlag
-        cpx #0
+        ; cpx #0 ; ldx sets z flag
         beq @notPAL
         lda #$66
 @notPAL:

--- a/src/playstate/spawnnext.asm
+++ b/src/playstate/spawnnext.asm
@@ -84,16 +84,16 @@ pickTetriminoPre:
         lda practiseType
         cmp #MODE_TSPINS
         beq pickTetriminoT
-        lda practiseType
+        ; lda practiseType ; accumulator is still practiseType
         cmp #MODE_SEED
         beq pickTetriminoSeed
-        lda practiseType
+        ; lda practiseType
         cmp #MODE_TAPQTY
         beq pickTetriminoLongbar
-        lda practiseType
+        ; lda practiseType
         cmp #MODE_TAP
         beq pickTetriminoLongbar
-        lda practiseType
+        ; lda practiseType
         cmp #MODE_PRESETS
         beq pickTetriminoPreset
         jmp pickRandomTetrimino
@@ -120,7 +120,7 @@ pickTetriminoSeed:
         ror
         and #$F
         ; v3
-        cmp #0
+        ; cmp #0 ; and sets z flag
         bne @notZero
         lda #$10
 @notZero:
@@ -128,6 +128,8 @@ pickTetriminoSeed:
         ; cmp #0
         ; beq @compatMode
 
+; without cmp #0, carry bit is unknown and needs set.
+        sec
         adc #1
         sta tmp3 ; step + 1 in tmp3
 @loop:

--- a/src/playstate/updatestats.asm
+++ b/src/playstate/updatestats.asm
@@ -178,7 +178,7 @@ addPointsRaw:
         cmp #MODE_TAPQTY
         bne @notTapQuantity
         lda completedLines
-        cmp #0
+        ; cmp #0 ; lda sets z flag
         bne @continueStreak
         jsr clearPoints
         lda outOfDateRenderFlags


### PR DESCRIPTION
These are a few minor optimizations that save a total of 70 bytes.

Comparisons to zero identified with `grep -RP 'cm?p[yx]?\s+#\$?0?0\b' ./src`

There were a few instances where the comparison was necessary as the zero flag would be unknown at the time of the comparison and were left alone.    The remaining instances were either commented out altogether or altered to produce the same result with fewer bytes.

There were also a few instances of values being loaded into the accumulator that were already there, identified with `grep -zoRP '(?mi)lda\s+(\w+)\s+cmp\s+\S+\s*$\s+b..\s+\S+\s*$\s+lda \1\s*$\s' src/`

Reference:
http://forum.6502.org/viewtopic.php?f=12&t=4434#p50991
http://www.6502.org/tutorials/6502opcodes.html



