### PR TITLE
Fix classic score renderer bug

### DIFF
--- a/src/nmi/render_score.asm
+++ b/src/nmi/render_score.asm
@@ -196,6 +196,7 @@ getScoreDiv100k:
         lsr
         lsr
         lsr
+        clc
         tax
         lda multBy100Table, x
         adc tmpZ


### PR DESCRIPTION
Fixes the classic score renderer erroneously adding 1 to the 100k's digit due to not clearing a carry flag.

This bug is triggered when the millions digit in the score has bit 3 set, and is the bug in P1xelAndy's [WR run](https://www.youtube.com/live/7Iz3Ogo3fUI?si=-2b7nPpPrvalTNKN&t=8188).