### PR TITLE
fix: seed low nybble decrement

### DIFF
--- a/src/gamemode/gametypemenu/menu.asm
+++ b/src/gamemode/gametypemenu/menu.asm
@@ -232,7 +232,6 @@ seedControls:
         jmp @skipSeedDown
 @lowNybbleDown:
         lda set_seed_input, x
-        clc
         tay
         and #$F
         ; cmp #$0 ; and sets z flag
@@ -245,6 +244,7 @@ seedControls:
         jmp @skipSeedDown
 @noWrapDown:
         tya
+        sec
         sbc #1
         sta set_seed_input, x
 @skipSeedDown:


### PR DESCRIPTION
By not doing the `cmp #$0`, the carry bit was cleared when the `sbc` occurred, subtracting 2 instead of 1.  