### PR TITLE
Fix linecap floor top row bug

### DIFF
--- a/src/gamemodestate/initstate.asm
+++ b/src/gamemodestate/initstate.asm
@@ -40,6 +40,15 @@ gameModeState_initGameState:
         sta linecapState
         sta dasOnlyShiftDisabled
         sta invisibleFlag
+        sta currentFloor
+
+; initialize currentFloor if necessary
+        lda practiseType
+        cmp #MODE_FLOOR
+        bne @notFloor
+        lda floorModifier
+        sta currentFloor
+@notFloor:
 
         lda practiseType
         cmp #MODE_INVISIBLE

--- a/src/modes/floor.asm
+++ b/src/modes/floor.asm
@@ -1,5 +1,5 @@
 advanceGameFloor:
-        lda floorModifier
+        lda currentFloor
 drawFloor:
         ; get correct offset
         sta tmp1

--- a/src/playstate/completedrows.asm
+++ b/src/playstate/completedrows.asm
@@ -45,7 +45,7 @@ playState_checkForCompletedRows:
         bne @normalRow
 
 @floorCheck:
-        lda floorModifier
+        lda currentFloor
         beq @rowNotComplete
 
 @fullRowBurningCheck:
@@ -53,7 +53,7 @@ playState_checkForCompletedRows:
         lda #$13
         sec
         sbc generalCounter2 ; contains current row being checked
-        cmp floorModifier
+        cmp currentFloor
         bcc @rowNotComplete ; ignore floor rows
 @normalRow:
 
@@ -98,7 +98,7 @@ playState_checkForCompletedRows:
         beq @incrementLineIndex
         lda #$14
         sec
-        sbc floorModifier
+        sbc currentFloor
         tax
         ldy multBy10Table,x
         ldx #$0A

--- a/src/playstate/updatestats.asm
+++ b/src/playstate/updatestats.asm
@@ -164,6 +164,7 @@ checkLinecap: ; set linecapState
         sta garbageHole
         lda #1
         sta pendingGarbage
+        inc currentFloor
 @floorLinecapEnd:
 
 addPoints:

--- a/src/ram.asm
+++ b/src/ram.asm
@@ -209,8 +209,9 @@ linecapState: .res 1 ; $639 ; 0 if not triggered, 1 + linecapHow otherwise, rese
 dasOnlyShiftDisabled: .res 1 ; $63A
 
 invisibleFlag: .res 1 ; $63B  ; 0 for normal mode, non-zero for Invisible playfield rendering.  Reset on game init and game over.
+currentFloor: .res 1 ; floorModifier is copied here at game init.  Set to #$14 for linecap floor and decremented during scoring.
 
-    .res $39
+    .res $38
 
 .if KEYBOARD
 newlyPressedKeys: .res 1 ; $0675

--- a/src/ram.asm
+++ b/src/ram.asm
@@ -209,7 +209,7 @@ linecapState: .res 1 ; $639 ; 0 if not triggered, 1 + linecapHow otherwise, rese
 dasOnlyShiftDisabled: .res 1 ; $63A
 
 invisibleFlag: .res 1 ; $63B  ; 0 for normal mode, non-zero for Invisible playfield rendering.  Reset on game init and game over.
-currentFloor: .res 1 ; floorModifier is copied here at game init.  Set to #$14 for linecap floor and decremented during scoring.
+currentFloor: .res 1 ; floorModifier is copied here at game init.  Set to 0 otherwise and incremented when linecap floor.
 
     .res $38
 


### PR DESCRIPTION
This fixes a bug introduced in #50

Replaced floorModifier with currentFloor.  This allows for linecap floor to modify the floor variable without modifying what's displayed for floor mode on the menu.  

Validated that floor mode 0 does not clear lines.  All other floor modes behave as expected.  Linecap floor works as expected, growing the floor each level up.  Linecap floor works with floor mode but with the only caveat being that normal floor mode uses BLOCK_TILES, while linecap floor uses BLOCK_TILES+3.