### PR TITLE
fix: don't black out palette when clearing nametable

### DIFF
--- a/src/util/core.asm
+++ b/src/util/core.asm
@@ -23,6 +23,7 @@ clearNametable:
         ldy #$FF
         dex
         bne @clearTile
+        rts
 
 drawBlackBGPalette:
         lda #$3F


### PR DESCRIPTION
Linecap menu was black text on black background making it difficult to read.