### PR TITLE
feature: playfield graphic function

### DIFF
--- a/src/playstate/preparenext.asm
+++ b/src/playstate/preparenext.asm
@@ -44,36 +44,18 @@ playState_prepareNext:
         lda linecapState
         cmp #LINECAP_HALT
         bne @linecapHaltEnd
-        lda #'G'
-        sta playfield+$67
-        sta playfield+$68
-        lda #$28
-        sta playfield+$6A
-        lda #0
-        sta vramRow
-        jsr typeBEndingStuffEnd
-        rts
+        ldx #<haltEndingGraphic
+        ldy #>haltEndingGraphic
+        jmp copyGraphic
 @linecapHaltEnd:
-
         jsr practisePrepareNext
         inc playState
         rts
-
 typeBEndingStuff:
-        ; copy success graphic
-        ldx #$5C
-        ldy #$0
-@copySuccessGraphic:
-        lda typebSuccessGraphic,y
-        cmp #$80
-        beq @graphicCopied
-        sta playfield,x
-        inx
-        iny
-        jmp @copySuccessGraphic
-@graphicCopied:
-        lda #$00
-        sta vramRow
+        ldx #<typebSuccessGraphic
+        ldy #>typebSuccessGraphic
+copyGraphic:
+        jsr copyGraphicToPlayfield
 
 typeBEndingStuffEnd:
         ; play sfx
@@ -98,5 +80,30 @@ sleep_gameplay_nextSprite:
         bne @loop
         rts
 
+copyGraphicToPlayfield:
+        lda #$09 ; default row
+copyGraphicToPlayfieldAtCustomRow:
+        stx generalCounter
+        sty generalCounter2
+        tax
+        lda multBy10Table,x
+        clc
+        adc #$02 ; indent
+        tax
+        ldy #$00
+@copySuccessGraphic:
+        lda (generalCounter),y
+        beq @graphicCopied
+        sta playfield,x
+        inx
+        iny
+        bne @copySuccessGraphic
+@graphicCopied: ; 0 in accumulator
+        sta vramRow
+        rts
+
+; $28 is ! in game tileset
+haltEndingGraphic:
+        .byte   $FF,"G","G",$FF,$28,$00
 typebSuccessGraphic:
-        .byte   $17,$12,$0C,$0E,$FF,$28,$80
+        .byte   "N","I","C","E",$FF,$28,$00


### PR DESCRIPTION
This change was part of the lowstack mode change.  Broke it out so it can be tested/incorporated separately to facilitate the crash graphic for Hydrant's crash mode.  

Supports an entrypoint that allows for setting a custom row to display the graphic, used in lowstack so the graphic never overlaps with the line.  