### PR TITLE
Harddrop tweaks

### DIFF
--- a/src/playstate/active.asm
+++ b/src/playstate/active.asm
@@ -38,8 +38,6 @@ harddrop_tetrimino:
         bne @sonic
         rts
 @sonic:
-        lda #0
-        sta vramRow
         lda #$D0
         sta autorepeatY
         rts

--- a/src/sprites/piece.asm
+++ b/src/sprites/piece.asm
@@ -136,6 +136,11 @@ stageSpriteForCurrentPiece_return:
         rts
 
 stageSpriteForNextPiece:
+        lda practiseType
+        cmp #MODE_HARDDROP
+        beq @alwaysNextBox
+        lda debugFlag
+        bne @alwaysNextBox
         lda displayNextPiece
         bne @ret
 


### PR DESCRIPTION
vramRow was being reset unnecessarily after a sonic drop.  This meant if hard drop occurred in the next 4 frames, lockTetrimino would exit prematurely and nothing would end up stored in the playfield.  

Also forced display of next piece when block tool is enabled and when in hard drop mode