### PR TITLE
Add negative delay to the hz display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
 * Famicom Keyboard support
 * MMC3 Support
 * MMC5 Support
+* Added "negative delay" to the hz display
+* Keep hz display enabled when topped out
 
 ## [v5 tournament]
 * Linecap Menu (from CTM Masters September 2022)

--- a/src/gamemodestate/initstate.asm
+++ b/src/gamemodestate/initstate.asm
@@ -149,6 +149,8 @@ gameModeState_initGameState:
 @noTypeBPlayfield:
 
         jsr hzStart
+        lda #0
+        sta hzSpawnDelay
         jsr practiseInitGameState
         jsr resetScroll
 

--- a/src/modes/hz.asm
+++ b/src/modes/hz.asm
@@ -9,7 +9,6 @@ hzDebounceThreshold := $10
 
 hzStart: ; called in playState_spawnNextTetrimino, gameModeState_initGameState, gameMode_gameTypeMenu
         lda #0
-        sta hzSpawnDelay
         sta hzTapCounter
         lda #hzDebounceThreshold
         sta hzDebounceCounter
@@ -50,7 +49,7 @@ hzControl: ; called in playState_playerControlsActiveTetrimino, gameTypeLoopCont
         bne @noDelayInc
         lda hzSpawnDelay
         cmp #$F
-        beq @noDelayInc
+        bcs @noDelayInc
         inc hzSpawnDelay
 @noDelayInc:
         rts
@@ -181,6 +180,33 @@ hzTap:
         lda renderFlags
         ora #RENDER_HZ
         sta renderFlags
+        rts
+
+; X: value to store if left or right is newly pressed
+checkNegativeDelay:
+        ; the tail of entry delay has two paths: a normal path, and one where
+        ; spawn delay is added (currently, tspins and debug mode)
+        ; if the spawn delay is too large, we shouldn't update here
+        lda spawnDelay
+        cmp #3
+        bcs @ret
+        lda hzSpawnDelay
+        bne @ret
+        lda newlyPressedButtons_player1
+        and #BUTTON_DPAD
+        cmp #BUTTON_LEFT
+        beq @setDelay
+        lda newlyPressedButtons_player1
+        and #BUTTON_DPAD
+        cmp #BUTTON_RIGHT
+        beq @setDelay
+        rts
+@setDelay:
+        stx hzSpawnDelay
+        lda renderFlags
+        ora #$10
+        sta renderFlags
+@ret:
         rts
 
 dasLimitLookup:

--- a/src/nmi/render_hz.asm
+++ b/src/nmi/render_hz.asm
@@ -1,15 +1,23 @@
 renderHz:
         ; only set at game start and when player is controlling a piece
         ; during which, no other tile updates are happening
-        ; this is pretty expensive and uses up $7 PPU tile writes and 1 palette write
+        ; this is pretty expensive and uses up $8 PPU tile writes and 1 palette write
 
         ; delay
 
         lda #$22
         sta PPUADDR
-        lda #$68
+        lda #$67
         sta PPUADDR
+        ldx #$24 ; minus sign
         lda hzSpawnDelay
+        and #$80
+        bne @isNegative
+        ldx #$FF ; blank tile
+@isNegative:
+        stx PPUDATA
+        lda hzSpawnDelay
+        and #$7F ; clear sign flag
         sta PPUDATA
 
 renderHzSpeedTest:

--- a/src/nmi/render_mode_play_and_demo.asm
+++ b/src/nmi/render_mode_play_and_demo.asm
@@ -93,7 +93,7 @@ render_mode_play_and_demo:
         and #RENDER_SCORE
         beq @renderHz
 
-        ; 9 safe tile writes freed from stats / hz
+        ; 7 safe tile writes freed from stats / hz
         ; (lazy render hz for 10 more)
         ; 1 added in level (3 total)
         ; 2 added in lines (5 total)

--- a/src/nmi/render_mode_play_and_demo.asm
+++ b/src/nmi/render_mode_play_and_demo.asm
@@ -93,7 +93,7 @@ render_mode_play_and_demo:
         and #RENDER_SCORE
         beq @renderHz
 
-        ; 8 safe tile writes freed from stats / hz
+        ; 9 safe tile writes freed from stats / hz
         ; (lazy render hz for 10 more)
         ; 1 added in level (3 total)
         ; 2 added in lines (5 total)

--- a/src/playstate/gameover_rocket.asm
+++ b/src/playstate/gameover_rocket.asm
@@ -1,4 +1,5 @@
 playState_checkStartGameOver:
+        jsr hzControl
 .if !ALWAYS_CURTAIN
         ; skip curtain / rocket when not qualling
         lda qualFlag

--- a/src/playstate/garbage.asm
+++ b/src/playstate/garbage.asm
@@ -37,8 +37,12 @@ playState_receiveGarbage:
         lda #$00
         sta pendingGarbage
         sta vramRow
-@ret:  inc playState
-@delay:  rts
+@ret:   inc playState
+        lda #$00 ; earliest possible measured point
+        sta hzSpawnDelay
+        ldx #$83 ; -3 tap delay
+        jsr checkNegativeDelay
+        rts
 
 
 garbageLines:

--- a/src/playstate/spawnnext.asm
+++ b/src/playstate/spawnnext.asm
@@ -3,11 +3,24 @@ SPAWN_NEXT_ADDONS := 1
 playState_spawnNextTetrimino:
         lda vramRow
         cmp #$20
-        bmi @ret
+        bpl :+
+        ldx #$82 ; -2 tap delay
+        jsr checkNegativeDelay
+        rts
 
+:
 .if SPAWN_NEXT_ADDONS
         lda spawnDelay
         beq @notDelaying
+        ; here, spawnDelay=1 means hzSpawnDelay=-2, 2 implies -3, and etc.
+        cmp #3 ; if spawnDelay is >= 3, don't update
+        bcs @noCheck
+        clc
+        adc #1
+        ora #$80 ; mark delay as negative
+        tax
+        jsr checkNegativeDelay
+@noCheck:
         dec spawnDelay
         jmp @ret
 .endif
@@ -24,7 +37,8 @@ playState_spawnNextTetrimino:
         sta saveStateDirty
         rts
 @noSaveState:
-
+        ldx #$81 ; -1 tap delay
+        jsr checkNegativeDelay
         jsr hzStart
 .endif
 

--- a/tests/src/cycle_count.rs
+++ b/tests/src/cycle_count.rs
@@ -1,7 +1,56 @@
 use crate::{util, score, labels, playfield};
-use rusticnes_core::nes::NesState;
 
 pub fn count_cycles() {
+    test_hz_cycles();
+    test_max_score_cycles();
+    test_mode_score_cycles();
+}
+
+fn test_hz_cycles() {
+    // check max hz calculation amount
+    let mut emu = util::emulator(None);
+
+    let hz_flag = labels::get("hzFlag") as usize;
+    let game_mode = labels::get("gameMode") as usize;
+    let x = labels::get("tetriminoX") as usize;
+    let y = labels::get("tetriminoY") as usize;
+    let main_loop = labels::get("mainLoop");
+    let level_number = labels::get("levelNumber") as usize;
+    let debounce = labels::get("hzDebounceThreshold") as usize;
+
+    util::run_n_vblanks(&mut emu, 3);
+
+    emu.memory.iram_raw[hz_flag] = 1;
+    emu.memory.iram_raw[level_number] = 18;
+    emu.memory.iram_raw[game_mode] = 4;
+    emu.registers.pc = main_loop;
+
+    util::run_n_vblanks(&mut emu, 5);
+
+    let mut highest = 0;
+
+    for buttons in &[
+        "L.L.L.L.L",
+        "RR...R...R...R.R.",
+        ".....L.L..L.L.",
+        "LLL..L.L...L.R.R..L...R....L....L...L....L",
+        "R.R.R.R.R.R.R.R.R.R.R.R.R.R.R.R.R.R.R.R.R.R.R.R.R.R.R.R.R.R.R.R.R",
+    ] {
+        buttons.chars().for_each(|button| {
+            emu.memory.iram_raw[x] = 5;
+            emu.memory.iram_raw[y] = 0;
+            util::set_controller(&mut emu, button);
+            highest = highest.max(util::cycles_to_vblank(&mut emu));
+        });
+
+        util::run_n_vblanks(&mut emu, debounce + 1);
+    }
+
+    println!("hz display most cycles {}", highest);
+}
+
+fn test_max_score_cycles() {
+    // check max scoring cycle amount
     let mut emu = util::emulator(None);
 
     let completed_lines = labels::get("completedLines") as usize;
@@ -18,7 +67,6 @@ pub fn count_cycles() {
 
     let mut highest = 0;
 
-    // check every linecount on every level
     for level in 0..=255 {
         for lines in 0..=4 {
             let count = score(999999, lines, level);
@@ -30,9 +78,10 @@ pub fn count_cycles() {
     }
 
     println!("scoring routine most cycles: {}", highest);
+}
 
+fn test_mode_score_cycles() {
     // check clock cycles frames in each mode
-
     let mut emu = util::emulator(None);
 
     for mode in 0..labels::get("MODE_GAME_QUANTITY") {
@@ -76,7 +125,7 @@ pub fn count_cycles() {
             emu.memory.iram_raw[labels::get("autorepeatY") as usize] = 0;
 
             for _ in 0..45 {
-                let cycles = cycles_to_vblank(&mut emu);
+                let cycles = util::cycles_to_vblank(&mut emu);
 
                 if cycles > highest {
                     highest = cycles;
@@ -88,64 +137,4 @@ pub fn count_cycles() {
 
         println!("cycles {} lines {} mode {}", highest, lines, mode);
     }
-
-}
-
-fn cycles_to_vblank(emu: &mut NesState) -> u32 {
-    let vblank = labels::get("verticalBlankingInterval") as usize;
-    let mut cycles = 0;
-    let mut done = false;
-
-    while emu.ppu.current_scanline == 242 {
-        emu.cycle();
-        if !done {
-            cycles += 1;
-            if emu.memory.iram_raw[vblank] == 1 {
-                done = true;
-            }
-        }
-        let mut i = 0;
-        while emu.cpu.tick >= 1 && i < 10 {
-            emu.cycle();
-            if !done {
-                cycles += 1;
-                if emu.memory.iram_raw[vblank] == 1 {
-                    done = true;
-                }
-            }
-            i += 1;
-        }
-        if emu.ppu.current_frame != emu.last_frame {
-            emu.event_tracker.swap_buffers();
-            emu.last_frame = emu.ppu.current_frame;
-        }
-    }
-    emu.memory.iram_raw[vblank] = 1;
-    done = false;
-    while emu.ppu.current_scanline != 242 {
-        emu.cycle();
-        if !done {
-            cycles += 1;
-            if emu.memory.iram_raw[vblank] == 0 {
-                done = true;
-            }
-        }
-        let mut i = 0;
-        while emu.cpu.tick >= 1 && i < 10 {
-            emu.cycle();
-            if !done {
-                cycles += 1;
-                if emu.memory.iram_raw[vblank] == 0 {
-                    done = true;
-                }
-            }
-            i += 1;
-        }
-        if emu.ppu.current_frame != emu.last_frame {
-            emu.event_tracker.swap_buffers();
-            emu.last_frame = emu.ppu.current_frame;
-        }
-    }
-
-    cycles
 }

--- a/tests/src/hz_display.rs
+++ b/tests/src/hz_display.rs
@@ -1,4 +1,4 @@
-use crate::{input, labels, util};
+use crate::{labels, util};
 use rusticnes_core::nes::NesState;
 
 pub fn test() {
@@ -9,9 +9,7 @@ pub fn test() {
 fn test_standard() {
     let mut emu = util::emulator(None);
 
-    for _ in 0..4 {
-        emu.run_until_vblank();
-    }
+    util::run_n_vblanks(&mut emu, 4);
 
     let hz_flag = labels::get("hzFlag") as usize;
     let game_mode = labels::get("gameMode") as usize;
@@ -90,25 +88,12 @@ fn test_tspin() {
     assert_hz_display(&mut emu, HzSpeed(0, 0), 1, -3, Dir::Right);
 }
 
-// note:
 fn run_input_string(emu: &mut NesState, inputs: &str) {
     for button in inputs.chars() {
-        let controller_data = match button {
-            'L' => input::LEFT,
-            'R' => input::RIGHT,
-            'D' => input::DOWN,
-            'U' => input::UP,
-            'A' => input::A,
-            'B' => input::B,
-            'S' => input::START,
-            'T' => input::SELECT,
-            '.' => 0,
-            _ => panic!("character '{}' cannot be used as controller input", button),
-        };
-        util::set_controller(emu, controller_data);
+        util::set_controller(emu, button);
         emu.run_until_vblank();
     }
-    util::set_controller(emu, 0);
+    util::set_controller(emu, '.');
 }
 
 #[derive(PartialEq)]

--- a/tests/src/hz_display.rs
+++ b/tests/src/hz_display.rs
@@ -1,0 +1,115 @@
+use crate::{input, labels, util};
+use rusticnes_core::nes::NesState;
+
+pub fn test() {
+    let mut emu = util::emulator(None);
+
+    for _ in 0..4 {
+        emu.run_until_vblank();
+    }
+
+    let hz_flag = labels::get("hzFlag") as usize;
+    let game_mode = labels::get("gameMode") as usize;
+    let main_loop = labels::get("mainLoop");
+    let level_number = labels::get("levelNumber") as usize;
+
+    // turn on hz display
+    emu.memory.iram_raw[hz_flag] = 1;
+    // trick game into thinking it should start an a-type run
+    emu.memory.iram_raw[level_number] = 29;
+    emu.memory.iram_raw[game_mode] = 4;
+    emu.registers.pc = main_loop;
+
+    // wait for piece to become active
+    util::run_n_vblanks(&mut emu, 5);
+    // test left input sequence with delay of 5
+    run_input_string(&mut emu, ".....L.L..L.L.");
+    assert_hz_display(&mut emu, HzSpeed(25, 75), 4, 5, Dir::Left);
+
+    // wait a little, then test right input sequence
+    util::run_n_vblanks(&mut emu, 5);
+    run_input_string(&mut emu, "R....R.R.");
+    assert_hz_display(&mut emu, HzSpeed(17, 17), 3, 5, Dir::Right);
+    // make piece fall immediately so emulation takes less time
+    run_input_string(&mut emu, "D");
+    // fall 18 rows, then 3 frames before the 10-frame entry delay finishes
+    util::run_n_vblanks(&mut emu, 18+10-3);
+    run_input_string(&mut emu, "R.R.R.R.R.");
+    assert_hz_display(&mut emu, HzSpeed(30, 5), 3, 1, Dir::Right);
+    // TODO: have tests for -2 and -1 entry delay too.
+    // each negative entry delay should have its own test because they all
+    // need to be handled specifically in separate branches
+}
+
+// note:
+fn run_input_string(emu: &mut NesState, inputs: &str) {
+    for button in inputs.chars() {
+        let controller_data = match button {
+            'L' => input::LEFT,
+            'R' => input::RIGHT,
+            'D' => input::DOWN,
+            'U' => input::UP,
+            'A' => input::A,
+            'B' => input::B,
+            'S' => input::START,
+            'T' => input::SELECT,
+            '.' => 0,
+            _ => panic!("character '{}' cannot be used as controller input", button),
+        };
+        util::set_controller(emu, controller_data);
+        emu.run_until_vblank();
+    }
+    util::set_controller(emu, 0);
+}
+
+#[derive(PartialEq)]
+struct HzSpeed (u8, u8);
+
+enum Dir {
+    Left,
+    Right,
+}
+
+fn assert_hz_display(emu: &mut NesState, speed: HzSpeed, tap: u8, dly: i8, dir: Dir) {
+    assert_speed(emu, speed);
+    assert_tap_count(emu, tap);
+    assert_tap_delay(emu, dly);
+    assert_tap_dir(emu, dir);
+}
+
+fn assert_speed(emu: &mut NesState, speed: HzSpeed) {
+    const HZ_ADDR: u16 = 0x21A3;
+    let int_part = 10 * emu.mapper.debug_read_ppu(HZ_ADDR).unwrap()
+        + emu.mapper.debug_read_ppu(HZ_ADDR+1).unwrap();
+    let frac_part = 10 * emu.mapper.debug_read_ppu(HZ_ADDR+3).unwrap()
+        + emu.mapper.debug_read_ppu(HZ_ADDR+4).unwrap();
+    assert!(speed == HzSpeed(int_part, frac_part));
+}
+
+fn assert_tap_count(emu: &mut NesState, tap: u8) {
+    const TAP_COUNT_ADDR: u16 = 0x2228;
+    assert!(tap == emu.mapper.debug_read_ppu(TAP_COUNT_ADDR).unwrap());
+}
+
+fn assert_tap_delay(emu: &mut NesState, dly: i8) {
+    const DELAY_ADDR: u16 = 0x2267;
+    // sign of delay value
+    let measured_sign = emu.mapper.debug_read_ppu(DELAY_ADDR).unwrap();
+    if dly < 0 {
+        assert!(measured_sign == 0x24);
+    } else {
+        assert!(measured_sign == 0xFF);
+    }
+    // magnitude
+    let measured_abs = emu.mapper.debug_read_ppu(DELAY_ADDR+1).unwrap();
+    assert!(measured_abs == dly.unsigned_abs());
+}
+
+fn assert_tap_dir(emu: &mut NesState, dir: Dir) {
+    const DIR_ADDR: u16 = 0x22A8;
+    let measured_dir = emu.mapper.debug_read_ppu(DIR_ADDR).unwrap();
+    match dir {
+        Dir::Left => assert!(measured_dir == 0xD7),
+        Dir::Right => assert!(measured_dir == 0xD6),
+    }
+}

--- a/tests/src/input.rs
+++ b/tests/src/input.rs
@@ -1,9 +1,9 @@
 #![allow(unused)]
-pub const DOWN: u8 = 4u8;
-pub const UP: u8 = 8u8;
-pub const RIGHT: u8 = 1u8;
-pub const LEFT: u8 = 2u8;
-pub const B: u8 = 40u8;
-pub const A: u8 = 80u8;
-pub const SELECT: u8 = 20u8;
-pub const START: u8 = 10u8;
+pub const DOWN: u8 = 0x4u8;
+pub const UP: u8 = 0x8u8;
+pub const RIGHT: u8 = 0x1u8;
+pub const LEFT: u8 = 0x2u8;
+pub const B: u8 = 0x40u8;
+pub const A: u8 = 0x80u8;
+pub const SELECT: u8 = 0x20u8;
+pub const START: u8 = 0x10u8;

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -17,6 +17,7 @@ mod sps;
 mod toprow;
 mod tspins;
 mod hz_display;
+mod nmi;
 
 use gumdrop::Options;
 
@@ -47,7 +48,7 @@ struct TestOptions {
 fn main() {
     let options = TestOptions::parse_args_default_or_exit();
 
-    let tests: [(&str, fn()); 11] = [
+    let tests: [(&str, fn()); 12] = [
         ("garbage4", garbage::test_garbage4_crash),
         ("floor", floor::test),
         ("tspins", tspins::test),
@@ -59,6 +60,7 @@ fn main() {
         ("sps", sps::test),
         ("palettes", palettes::test),
         ("hz_display", hz_display::test),
+        ("nmi", nmi::test),
     ];
 
     // run tests

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -16,6 +16,7 @@ mod score;
 mod sps;
 mod toprow;
 mod tspins;
+mod hz_display;
 
 use gumdrop::Options;
 
@@ -46,7 +47,7 @@ struct TestOptions {
 fn main() {
     let options = TestOptions::parse_args_default_or_exit();
 
-    let tests: [(&str, fn()); 10] = [
+    let tests: [(&str, fn()); 11] = [
         ("garbage4", garbage::test_garbage4_crash),
         ("floor", floor::test),
         ("tspins", tspins::test),
@@ -57,6 +58,7 @@ fn main() {
         ("rng seeds", rng::test),
         ("sps", sps::test),
         ("palettes", palettes::test),
+        ("hz_display", hz_display::test),
     ];
 
     // run tests

--- a/tests/src/nmi.rs
+++ b/tests/src/nmi.rs
@@ -1,0 +1,73 @@
+use crate::{labels, playfield, util};
+
+/// makes sure nmi exits quickly enough
+pub fn test() {
+    let mut emu = util::emulator(None);
+
+    let main_loop = labels::get("mainLoop");
+    let game_mode = labels::get("gameMode") as usize;
+    let level_number = labels::get("levelNumber") as usize;
+    let nmi_label = labels::get("nmi");
+    let hz_flag = labels::get("hzFlag") as usize;
+    let render_flags = labels::get("renderFlags") as usize;
+
+    // spend a few frames bootstrapping
+    for _ in 0..3 {
+        emu.run_until_vblank();
+    }
+
+    // copied setup from garbage.rs
+    emu.memory.iram_raw[hz_flag] = 1;
+    emu.memory.iram_raw[game_mode] = 4;
+    emu.memory.iram_raw[level_number] = 18;
+    emu.registers.pc = main_loop;
+
+    for _ in 0..11 {
+        emu.run_until_vblank();
+    }
+
+    // sets up a triple in the top of the board
+    emu.memory.iram_raw[labels::get("currentPiece") as usize] = 0x0F; // L piece
+    emu.memory.iram_raw[labels::get("tetriminoX") as usize] = 0x6;
+    emu.memory.iram_raw[labels::get("tetriminoY") as usize] = 0x0;
+    emu.memory.iram_raw[labels::get("vramRow") as usize] = 0;
+    emu.memory.iram_raw[labels::get("autorepeatY") as usize] = 0;
+
+    playfield::set_str(&mut emu, r##"
+#####  ###
+#####  ###
+###### ###
+###### ###
+######### 
+######### 
+######### 
+######### 
+######### 
+######### 
+######### 
+######### 
+######### 
+######### 
+######### 
+######### 
+######### 
+######### 
+######### 
+######### "##);
+
+    for _ in 0..50 {
+        // loop until pc is at the instruction after the jsr copyOamStagingToOam
+        while emu.registers.pc != nmi_label + 25 {
+            emu.step();
+            if emu.ppu.current_scanline == 261 {
+                panic!("render took too long!");
+            }
+        }
+        // cannot render hz on the same frame score/lines are updated
+        let state = emu.memory.iram_raw[labels::get("playState") as usize];
+        if state != 5 {
+            emu.memory.iram_raw[render_flags] |= 0x10;
+        }
+        emu.run_until_vblank();
+    }
+}

--- a/tests/src/video.rs
+++ b/tests/src/video.rs
@@ -1,5 +1,5 @@
 use rusticnes_core::nes::NesState;
-use minifb::{Window, WindowOptions};
+use minifb::{Window, WindowOptions, Key, KeyRepeat};
 
 pub const WIDTH: usize = 256;
 pub const HEIGHT: usize = 240;
@@ -28,5 +28,25 @@ impl Video {
     pub fn render(&mut self, emu: &mut NesState) {
         emu.ppu.render_ntsc(WIDTH);
         self.window.update_with_buffer(&emu.ppu.filtered_screen, WIDTH, HEIGHT).unwrap();
+    }
+}
+
+/// debug helper for showing the current visual state.
+/// hotkeys: 'q' closes window, 's' steps by a frame
+#[allow(dead_code)]
+pub fn preview(emu: &mut NesState) {
+    let mut view = Video::new();
+    view.window.set_key_repeat_rate(0.1);
+    loop {
+        if !view.window.is_open() {
+            break;
+        }
+        if view.window.is_key_pressed(Key::Q, KeyRepeat::No) {
+            break;
+        }
+        if view.window.is_key_pressed(Key::S, KeyRepeat::Yes) {
+            emu.run_until_vblank();
+        }
+        view.render(emu);
     }
 }


### PR DESCRIPTION
See title. In addition, I wrote a couple of light tests and kept the hz display enabled during topout (quality of life thing I've wanted for a while). More detailed notes on the process can be found [here](https://github.com/kirjavascript/TetrisGYM/commit/2fc570e8f92f9258a05907edf3b6743433f21a24) and [here](https://github.com/kirjavascript/TetrisGYM/commit/938d0666d6b61c9202de3465e944e09a0f5458f0).

testing is very cool i kind of want to add stuff for crash gym but that seems like a lot so maybe later