### PR TITLE
Finishing touches to crash detection

### DIFF
--- a/src/modes/crash.asm
+++ b/src/modes/crash.asm
@@ -379,6 +379,7 @@ testCrash:
         beq @noLag ;if lag should happen, wait a frame here so that sprite staging doesn't happen.
         lda #$00
         sta verticalBlankingInterval
+		sta lagState ;clear lagstate for next
 @checkForNmi:
         lda verticalBlankingInterval ;busyloop
         beq @checkForNmi

--- a/src/modes/crash.asm
+++ b/src/modes/crash.asm
@@ -286,6 +286,11 @@ testCrash:
         jsr satanSpawn
         jmp @allegroClear ;allegroClear is basically return, just clears the variable first.
 @isPal:
+		lda palFlag
+		beq @nextSwitch ;if NTSC, continue, no crash.
+		jsr blackBox
+@allegroJump:
+		jmp @allegroClear
         lda palFlag
         beq @nextSwitch ;if NTSC, continue, no crash.
         jsr blackBox
@@ -314,9 +319,15 @@ testCrash:
 @nextOn:
         lda cycleCount ;testing for limited confetti
         cmp #$76 ;high byte min
-        bcc @allegroClear
+        bcc @allegroJump
         bne @not76
         lda cycleCount+1
+		ldx strictFlag
+		beq @notStrict_confetti
+		cmp #$BD
+		bcc @allegroJump
+		bcs @confettiA
+@notStrict_confetti:
         cmp #$C5 ;low byte min
         bcc @allegroClear
         bcs @confettiA
@@ -337,6 +348,12 @@ testCrash:
         bcc @allegroClear
         bne @levelLag
         lda cycleCount+1
+		ldx strictFlag
+		beq @notStrict_level
+		cmp #$95
+		bcc @allegroClear
+		bcs @levelLag
+@notStrict_level:
         cmp #$9D;low byte min
         bcc @allegroClear
 @levelLag:
@@ -348,6 +365,12 @@ testCrash:
         bcc @allegroClear
         bne @lineLag
         lda cycleCount+1
+		ldx strictFlag
+		beq @notStrict_lines
+		cmp #$58
+		bcc @allegroClear
+		bcs @lineLag
+@notStrict_lines:
         cmp #$60;low byte min
         bcc @allegroClear
 @lineLag:
@@ -359,6 +382,12 @@ testCrash:
         bcc @allegroClear
         bne @not7A
         lda cycleCount+1
+		ldx strictFlag
+		beq @notStrict_B
+		cmp #$57
+		bcc @allegroClear
+		bcs @confettiB
+@notStrict_B:
         cmp #$5F ;low byte min
         bcc @allegroClear
         bcs @confettiB


### PR DESCRIPTION
A bugfix for lag frames happening when they aren't supposed to, and strict mode now applies to confetti, desyncs, etc.