### PR TITLE
Upgrade to NES2.0 header

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ A link to the BPS can be found on the [releases page](https://github.com/kirjava
 
 The BPS produces a file with its header specifying MMC1 with fixed PRG (mapper 1:5), but it also works when specified as CNROM with bus conflicts (mapper 3:2).
 
+If you are using a PowerPak, you will need to install an [alternate N.MAP loader](https://forums.nesdev.org/viewtopic.php?p=283943#p283943) so its header check passes.
+
 ## Trainers
 
 Some trainers have additional configuration values; use left and right in the main menu to change them.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ ROM CRC32: 1394F57E
 
 A link to the BPS can be found on the [releases page](https://github.com/kirjavascript/TetrisGYM/releases).
 
-The BPS produces a file with an NES2.0 header specifying MMC1 with fixed PRG (mapper 1:5), but it also works when specified as CNROM with bus conflicts (mapper 3:2).
+The BPS produces a file with its header specifying MMC1 with fixed PRG (mapper 1:5), but it also works when specified as CNROM with bus conflicts (mapper 3:2).
 
 ## Trainers
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ ROM CRC32: 1394F57E
 
 A link to the BPS can be found on the [releases page](https://github.com/kirjavascript/TetrisGYM/releases).
 
-The BPS produces a file with an MMC1 header, but it also works when treated as CNROM.
+The BPS produces a file with an NES2.0 header specifying MMC1 with fixed PRG (mapper 1:5), but it also works when specified as CNROM with bus conflicts (mapper 3:2).
 
 ## Trainers
 

--- a/build.js
+++ b/build.js
@@ -27,6 +27,7 @@ if (args.includes('-h')) {
 -k  Famicom Keyboard support
 -w  force WASM compiler
 -c  force PNG to CHR conversion
+-i  use iNES header instead of NES2.0
 -o  override autodetect mmc1 header with cnrom
 -t  run tests (requires cargo)
 -h  you are here
@@ -80,6 +81,11 @@ if (args.includes('-k')) {
 if (args.includes('-s')) {
     compileFlags.push('-D', 'SAVE_HIGHSCORES=0');
     console.log('highscore saving disabled');
+}
+
+if (args.includes('-i')) {
+    compileFlags.push('-D', 'INES_OVERRIDE=1');
+    console.log('iNES header override');
 }
 
 if (args.includes('-o')) {

--- a/src/constants.asm
+++ b/src/constants.asm
@@ -15,6 +15,10 @@ AUTO_WIN := 0
 KEYBOARD := 0
 .endif
 
+.ifndef INES_OVERRIDE
+INES_OVERRIDE := 0
+.endif
+
 .ifndef CNROM_OVERRIDE
 CNROM_OVERRIDE := 0
 .endif

--- a/src/header.asm
+++ b/src/header.asm
@@ -43,7 +43,7 @@ NES2_INPUT = 1 ; 1 = standard NES/FC controllers
 
 .if INES_OVERRIDE = 0
     .byte (_INES_MAPPER & %11110000) | %00001000 ; NES2.0 header identifier
-    .byte ((NES2_SUBMAPPER & $f) << 4) ; submapper
+    .byte ((NES2_SUBMAPPER & $f) << 4) | ((_INES_MAPPER & $f00) >> 8) ; submapper/mapper MSB
     .byte $0, (NES2_SRAM_SHIFT << 4) ; PRG MSB, SRAM shift count
     .byte $0, NES2_REGION, $0, $0, NES2_INPUT ; misc. fields, region, input device
 .else

--- a/src/header.asm
+++ b/src/header.asm
@@ -35,11 +35,19 @@ NES2_INPUT = 1 ; 1 = standard NES/FC controllers
     NES2_SUBMAPPER = 0 ; otherwise don't specify submapper
 .endif
 
+; Construct header
 .byte 'N', 'E', 'S', $1A ; ID
 .byte $02 ; 16k PRG chunk count
 .byte $02 ; 8k CHR chunk count
 .byte INES_MIRROR | (INES_SRAM << 1) | ((_INES_MAPPER & $f) << 4)
-.byte (_INES_MAPPER & %11110000) | %00001000 ; NES2.0 header identifier
-.byte ((NES2_SUBMAPPER & $f) << 4) ; submapper
-.byte $0, (NES2_SRAM_SHIFT << 4) ; PRG MSB, SRAM shift count
-.byte $0, NES2_REGION, $0, $0, NES2_INPUT ; misc. fields, region, input device
+
+.if INES_OVERRIDE = 0
+    .byte (_INES_MAPPER & %11110000) | %00001000 ; NES2.0 header identifier
+    .byte ((NES2_SUBMAPPER & $f) << 4) ; submapper
+    .byte $0, (NES2_SRAM_SHIFT << 4) ; PRG MSB, SRAM shift count
+    .byte $0, NES2_REGION, $0, $0, NES2_INPUT ; misc. fields, region, input device
+.else
+    .byte (_INES_MAPPER & %11110000)
+    .byte $0, $0, $0, $0, $0, $0, $0, $0 ; padding
+.endif
+

--- a/src/header.asm
+++ b/src/header.asm
@@ -1,8 +1,8 @@
 ;
-; iNES header
+; NES2.0 header
 ;
 
-; This iNES header is from Brad Smith (rainwarrior)
+; iNES header adapted from Brad Smith (rainwarrior)
 ; https://github.com/bbbradsmith/NES-ca65-example
 
 .segment "HEADER"
@@ -11,6 +11,9 @@
 
 INES_MIRROR = 0 ; 0 = horizontal mirroring, 1 = vertical mirroring (ignored in MMC1)
 INES_SRAM   = 1 ; 1 = battery backed SRAM at $6000-7FFF
+NES2_SRAM_SHIFT = INES_SRAM * 7 ; if SRAM present, set shift to 7 for (64 << 7) = 8KiB size
+NES2_REGION = 2 ; 0 = NTSC, 1 = PAL, 2 = multi-region, 3 = UA6538 ("Dendy")
+NES2_INPUT = 1 ; 1 = standard NES/FC controllers
 
 ; Override INES_MAPPER for mode 1000 (auto detect)
 .if INES_MAPPER = 1000
@@ -20,12 +23,23 @@ INES_SRAM   = 1 ; 1 = battery backed SRAM at $6000-7FFF
     _INES_MAPPER = 1 ; MMC1 for Emulator/Flashcart
     .endif
 .else
-_INES_MAPPER = INES_MAPPER ; use actual INES_MAPPER otherwise
+    _INES_MAPPER = INES_MAPPER ; use actual INES_MAPPER otherwise
+.endif
+
+; Pick the appropriate NES2_SUBMAPPER
+.if _INES_MAPPER = 1
+    NES2_SUBMAPPER = 5 ; MMC1 fixed PRG
+.elseif _INES_MAPPER = 3
+    NES2_SUBMAPPER = 2 ; CNROM bus conflicts
+.else
+    NES2_SUBMAPPER = 0 ; otherwise don't specify submapper
 .endif
 
 .byte 'N', 'E', 'S', $1A ; ID
 .byte $02 ; 16k PRG chunk count
 .byte $02 ; 8k CHR chunk count
 .byte INES_MIRROR | (INES_SRAM << 1) | ((_INES_MAPPER & $f) << 4)
-.byte (_INES_MAPPER & %11110000)
-.byte $0, $0, $0, $0, $0, $0, $0, $0 ; padding
+.byte (_INES_MAPPER & %11110000) | %00001000 ; NES2.0 header identifier
+.byte ((NES2_SUBMAPPER & $f) << 4) ; submapper
+.byte $0, (NES2_SRAM_SHIFT << 4) ; PRG MSB, SRAM shift count
+.byte $0, NES2_REGION, $0, $0, NES2_INPUT ; misc. fields, region, input device

--- a/src/header.asm
+++ b/src/header.asm
@@ -11,7 +11,7 @@
 .include "constants.asm" ; for INES_HEADER
 
 INES_MIRROR = 0 ; 0 = horizontal mirroring, 1 = vertical mirroring (ignored in MMC1)
-INES_SRAM   = 1 ; 1 = battery backed SRAM at $6000-7FFF
+INES_SRAM = SAVE_HIGHSCORES ; 1 = battery backed SRAM at $6000-7FFF
 NES2_SRAM_SHIFT = INES_SRAM * 7 ; if SRAM present, set shift to 7 for (64 << 7) = 8KiB size
 NES2_REGION = 2 ; 0 = NTSC, 1 = PAL, 2 = multi-region, 3 = UA6538 ("Dendy")
 

--- a/src/header.asm
+++ b/src/header.asm
@@ -1,5 +1,6 @@
 ;
 ; NES2.0 header
+; https://www.nesdev.org/wiki/NES_2.0
 ;
 
 ; iNES header adapted from Brad Smith (rainwarrior)
@@ -13,7 +14,13 @@ INES_MIRROR = 0 ; 0 = horizontal mirroring, 1 = vertical mirroring (ignored in M
 INES_SRAM   = 1 ; 1 = battery backed SRAM at $6000-7FFF
 NES2_SRAM_SHIFT = INES_SRAM * 7 ; if SRAM present, set shift to 7 for (64 << 7) = 8KiB size
 NES2_REGION = 2 ; 0 = NTSC, 1 = PAL, 2 = multi-region, 3 = UA6538 ("Dendy")
-NES2_INPUT = 1 ; 1 = standard NES/FC controllers
+
+; Pick default expansion device
+.if KEYBOARD = 1
+	NES2_INPUT = $23 ; Family BASIC Keyboard
+.else
+	NES2_INPUT = 1 ; standard NES/FC controllers
+.endif
 
 ; Override INES_MAPPER for mode 1000 (auto detect)
 .if INES_MAPPER = 1000


### PR DESCRIPTION
This PR upgrades the header from iNES to the forwards-compatible [NES2.0](https://www.nesdev.org/wiki/NES_2.0) in order to better describe the cart specification:
- Add NES2.0 header support (closely matches the header from nointro for the MMC1 configuration)
- Reflect the `SAVE_HIGHSCORES` flag in the header (previously, SRAM was always enabled in the header)
- Add `-i` build flag for legacy iNES header support
- Document workaround for NES2.0 header issues on PowerPak

With the BPS patch now being header-agnostic, this should help with adapting to the transition from iNES to NES2.0. (e.g. as seen in #19)

