### PR TITLE
linecap floor logic occurs when levelups possible

### DIFF
--- a/src/modes/floor.asm
+++ b/src/modes/floor.asm
@@ -9,8 +9,8 @@ drawFloor:
         ; x10
         lda multBy10Table, x
         tax
-        ; draw block tiles ($7B)
-        lda #BLOCK_TILES
+        ; draw block tiles+3 ($7E)
+        lda #BLOCK_TILES+3
 @loop:
         sta playfield+$46,X
         inx

--- a/src/playstate/completedrows.asm
+++ b/src/playstate/completedrows.asm
@@ -102,7 +102,7 @@ playState_checkForCompletedRows:
         tax
         ldy multBy10Table,x
         ldx #$0A
-        lda #BLOCK_TILES
+        lda #BLOCK_TILES+3
 @drawFloorSurface:
         sta playfield,y
         iny

--- a/src/playstate/updatestats.asm
+++ b/src/playstate/updatestats.asm
@@ -1,3 +1,5 @@
+levelUpPossible = generalCounter3
+
 playState_updateLinesAndStatistics:
         jsr updateMusicSpeed
         lda completedLines
@@ -5,6 +7,8 @@ playState_updateLinesAndStatistics:
         jmp addPoints
 
 @linesCleared:
+        ldy #$00
+        sty levelUpPossible
         tax
         dec lineClearStatsByType-1,x
         bpl @noCarry
@@ -75,6 +79,7 @@ checkLevelUp:
         and #$0F
         bne @lineLoop
 
+        inc levelUpPossible ; used by floorcap check below
         lda practiseType
         cmp #MODE_TAPQTY
         beq @lineLoop
@@ -115,7 +120,7 @@ checkLevelUp:
         lda crashState
         ora #$08
         sta crashState
-        lda #$06 ; checked in floor linecap stuff, just below
+        lda #$06
         sta soundEffectSlot1Init
         lda renderFlags
         ora #RENDER_LEVEL
@@ -167,10 +172,9 @@ checkLinecap: ; set linecapState
         lda linecapState
         cmp #LINECAP_FLOOR
         bne @floorLinecapEnd
-        ; check level up sound is happening
-        lda soundEffectSlot1Init
-        cmp #6
-        bne @floorLinecapEnd
+        ; check level up was possible
+        lda levelUpPossible
+        beq @floorLinecapEnd
         lda #$A
         sta garbageHole
         lda #1

--- a/src/playstate/updatestats.asm
+++ b/src/playstate/updatestats.asm
@@ -1,4 +1,4 @@
-levelUpPossible = generalCounter3
+; y reg tracks lines crossing multiple of 10 from @linesCleared until addPoints
 
 playState_updateLinesAndStatistics:
         jsr updateMusicSpeed
@@ -8,7 +8,6 @@ playState_updateLinesAndStatistics:
 
 @linesCleared:
         ldy #$00
-        sty levelUpPossible
         tax
         dec lineClearStatsByType-1,x
         bpl @noCarry
@@ -79,7 +78,7 @@ checkLevelUp:
         and #$0F
         bne @lineLoop
 
-        inc levelUpPossible ; used by floorcap check below
+        iny ; used by floorcap check below
         lda practiseType
         cmp #MODE_TAPQTY
         beq @lineLoop
@@ -173,7 +172,7 @@ checkLinecap: ; set linecapState
         cmp #LINECAP_FLOOR
         bne @floorLinecapEnd
         ; check level up was possible
-        lda levelUpPossible
+        tya
         beq @floorLinecapEnd
         lda #$A
         sta garbageHole

--- a/tests/src/floor.rs
+++ b/tests/src/floor.rs
@@ -1,4 +1,4 @@
-use crate::{util, labels, playfield, video};
+use crate::{util, labels, playfield};
 
 pub fn test() {
     test_floor();

--- a/tests/src/floor.rs
+++ b/tests/src/floor.rs
@@ -2,8 +2,8 @@ use crate::{util, labels, playfield};
 
 pub fn test() {
     test_floor();
-    test_floor_linecap_level();
-    test_floor_linecap_lines();
+    test_floor_linecap("MODE_TRANSITION",0);
+    test_floor_linecap("MODE_TETRIS",1);
     test_floor0();
 }
 
@@ -55,25 +55,27 @@ fn test_floor() {
     assert_ne!(playfield::get(&mut emu, 0, 19), 0xEF);
 }
 
-fn test_floor_linecap_lines() {
+fn test_floor_linecap(mode: &str, linecap_when: u8) {
 
     let mut emu = util::emulator(None);
 
     for _ in 0..3 { emu.run_until_vblank(); }
 
+    let practise_type = labels::get("practiseType") as usize;
     let game_mode = labels::get("gameMode") as usize;
     let main_loop = labels::get("mainLoop");
     let level_number = labels::get("levelNumber") as usize;
 
+    emu.memory.iram_raw[practise_type] = labels::get(mode) as _;
     emu.memory.iram_raw[level_number] = 19;
     emu.memory.iram_raw[game_mode] = 4;
 
     emu.memory.iram_raw[labels::get("linecapFlag") as usize] = 1;
-    emu.memory.iram_raw[labels::get("linecapWhen") as usize] = 1;
+    emu.memory.iram_raw[labels::get("linecapWhen") as usize] = linecap_when;
     emu.memory.iram_raw[labels::get("linecapHow") as usize] = labels::get("LINECAP_FLOOR") as u8 - 1;
     emu.memory.iram_raw[labels::get("linecapLines") as usize] = 0x10;
     emu.memory.iram_raw[labels::get("linecapLines") as usize + 1] = 0;
-
+    emu.memory.iram_raw[labels::get("linecapLevel") as usize] = 20;
 
     emu.registers.pc = main_loop;
 
@@ -97,59 +99,6 @@ fn test_floor_linecap_lines() {
 
         for _ in 0..40 { emu.run_until_vblank();}
 
-    }
-
-    // check rows aren't pulled from the top in linecap floor mode
-    for i in 0..40 {
-        assert_eq!(emu.memory.iram_raw[i + labels::get("playfield") as usize], 0xEF);
-    }
-
-    // check the floor is there
-    assert_ne!(playfield::get(&mut emu, 0, 19), 0xEF);
-    // but the row above isn't
-    assert_eq!(playfield::get(&mut emu, 0, 18), 0xEF);
-}
-
-fn test_floor_linecap_level() {
-
-    let mut emu = util::emulator(None);
-
-    for _ in 0..3 { emu.run_until_vblank(); }
-
-    let practise_type = labels::get("practiseType") as usize;
-    let game_mode = labels::get("gameMode") as usize;
-    let main_loop = labels::get("mainLoop");
-    let level_number = labels::get("levelNumber") as usize;
-
-    emu.memory.iram_raw[practise_type] = labels::get("MODE_TRANSITION") as _;
-    emu.memory.iram_raw[level_number] = 19;
-    emu.memory.iram_raw[game_mode] = 4;
-
-    emu.memory.iram_raw[labels::get("linecapFlag") as usize] = 1;
-    emu.memory.iram_raw[labels::get("linecapHow") as usize] = labels::get("LINECAP_FLOOR") as u8 - 1;
-    emu.memory.iram_raw[labels::get("linecapLevel") as usize] = 20;
-
-    emu.registers.pc = main_loop;
-
-    for _ in 0..5 { emu.run_until_vblank(); }
-
-    // get some tetrises
-
-    for _ in 0..4 {
-
-        emu.memory.iram_raw[labels::get("currentPiece") as usize] = 0x11;
-        emu.memory.iram_raw[labels::get("tetriminoX") as usize] = 0x5;
-        emu.memory.iram_raw[labels::get("tetriminoY") as usize] = 0x11;
-        emu.memory.iram_raw[labels::get("autorepeatY") as usize] = 0;
-        emu.memory.iram_raw[labels::get("vramRow") as usize] = 0;
-
-        playfield::set_str(&mut emu, r##"
-##### ####
-##### ####
-##### ####
-##### ####"##);
-
-        for _ in 0..40 { emu.run_until_vblank(); }
     }
 
     // check rows aren't pulled from the top in linecap floor mode

--- a/tests/src/floor.rs
+++ b/tests/src/floor.rs
@@ -56,7 +56,6 @@ fn test_floor() {
 }
 
 fn test_floor_linecap(mode: &str, linecap_when: u8) {
-
     let mut emu = util::emulator(None);
 
     for _ in 0..3 { emu.run_until_vblank(); }
@@ -97,8 +96,7 @@ fn test_floor_linecap(mode: &str, linecap_when: u8) {
 ##### ####
 ##### ####"##);
 
-        for _ in 0..40 { emu.run_until_vblank();}
-
+        for _ in 0..40 { emu.run_until_vblank(); }
     }
 
     // check rows aren't pulled from the top in linecap floor mode


### PR DESCRIPTION
Re: #104 

Line based floor caps outside of levelups were broken.  This uses a temp variable to track when the linecounter crosses a multiple of 10 so the appropriate logic can be applied.

This also modifies the floor tile used so linecap floor & regular floor modes match.

