### PR TITLE
Reset spawnID between SPS sequence tests

### DIFF
--- a/tests/src/sps.rs
+++ b/tests/src/sps.rs
@@ -13,6 +13,7 @@ impl SPS {
     }
 
     pub fn set_input(&mut self, seed: (u8, u8, u8)) {
+        self.emu.memory.iram_raw[labels::get("spawnID") as usize] = 0;
         self.emu.memory.iram_raw[(labels::get("set_seed_input") + 0) as usize] = seed.0;
         self.emu.memory.iram_raw[(labels::get("set_seed") + 0) as usize] = seed.0;
         self.emu.memory.iram_raw[(labels::get("set_seed_input") + 1) as usize] = seed.1;


### PR DESCRIPTION
Noticed that `000206` gave the wrong first piece when compared to the actual game, tracked it down to spawnID not being zero at the beginning of the sequence.  