### PR TITLE
Read tile from nametable in tspins test

### DIFF
--- a/tests/src/tspins.rs
+++ b/tests/src/tspins.rs
@@ -33,6 +33,8 @@ pub fn test() {
 ##########
     "##.trim(), playfield::get_str(&emu).trim());
 
+    // check that correct tile is rendered
+    assert_eq!(emu.ppu.read_byte(&mut *emu.mapper, 0x22CC), 0x7b);
     // check pixel is actually rendered
     assert_eq!(emu.ppu.screen[offset(96, 176) as usize], 0x30);
 }


### PR DESCRIPTION
There's no issue with the current test in place, but I remember it taking a little bit of effort to figure out how to read a tile from the nametable.  This serves as a reminder for how to do the same if it's ever needed again.