### PR TITLE
Reset scores when no SRAM is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [unreleased]
 
 * Fixed line based floor caps outside of levelups
+* Reset scores when no SRAM is present
 
 ## v6
 * Crunch Trainer
@@ -62,9 +63,9 @@
 * Start on any level
 * Rewrite of all scoring code
     * Classic scoring
-    * Millions counter 
+    * Millions counter
     * 7 digit score
-    * 999999 scorecap 
+    * 999999 scorecap
     * Fixed T-Spin scoring
     * Crash free with no long frames
 * Rewrite of all highscore code
@@ -87,7 +88,7 @@
 * Added option to disable tetris flashing
 * Changes made to more closely match the original ROM
     * Restore seed shredding on level menu
-    * Hold `select` to start in Qual Mode and reset level cursor 
+    * Hold `select` to start in Qual Mode and reset level cursor
     * Transition from Legal to Title screen after 512 frames
     * Hide next box between Curtain and Rocket
     * Persist Qual Mode (and menu config) between reset button presses
@@ -157,7 +158,7 @@
 - Garbage Trainer
     - Always Tetris Ready
     - Normal Garbage
-    - Smart Garbage 
+    - Smart Garbage
     - Hard Garbage
     - Infinite Digging
 - Piece distribution in Setups Trainer is now even

--- a/src/gamemode/levelmenu.asm
+++ b/src/gamemode/levelmenu.asm
@@ -77,7 +77,6 @@ gameMode_levelMenu_processPlayer1Navigation:
         lda newlyPressedButtons_player1
         sta newlyPressedButtons
 
-.if SAVE_HIGHSCORES
         lda levelControlMode
         cmp #4
         bne @notClearingHighscores
@@ -89,11 +88,15 @@ gameMode_levelMenu_processPlayer1Navigation:
         lda #0
         sta levelControlMode
         jsr resetScores
+.if SAVE_HIGHSCORES
+        jsr detectSRAM
+        beq @notResettingSavedScores
         jsr resetSavedScores
+@notResettingSavedScores:
+.endif
         jsr updateAudioWaitForNmiAndResetOamStaging
         jmp gameMode_levelMenu
 @notClearingHighscores:
-.endif
 
         jsr levelControl
         jsr levelMenuRenderHearts
@@ -191,7 +194,6 @@ levelControl:
         .addr   levelControlClearHighScores
         .addr   levelControlClearHighScoresConfirm
 
-.if SAVE_HIGHSCORES
 levelControlClearHighScores:
         lda #$20
         sta spriteXOffset
@@ -238,13 +240,7 @@ highScoreClearUpOrLeave:
         sta levelControlMode
 @ret:
         rts
-.else
-levelControlClearHighScores:
-levelControlClearHighScoresConfirm:
-        lda #0
-        sta levelControlMode
-        rts
-.endif
+
 
 levelControlCustomLevel:
         jsr handleReadyInput
@@ -324,10 +320,7 @@ MAX_HEARTS := 7
         jsr @changeHearts
 @checkUpPressed:
 
-.if SAVE_HIGHSCORES
         ; to clear mode
-        jsr detectSRAM
-        beq @notClearMode
         lda newlyPressedButtons
         cmp #BUTTON_DOWN
         bne @notClearMode
@@ -336,7 +329,6 @@ MAX_HEARTS := 7
         lda #$3
         sta levelControlMode
 @notClearMode:
-.endif
 
         ; to normal mode
         lda newlyPressedButtons


### PR DESCRIPTION
Opens up most of the score reset code to be default and not behind the build flag. 

Code to clear saved high scores is still behind build flag and detects SRAM before resetting. 

