### PR TITLE
Ignore crunch columns during allegro check

### DIFF
--- a/src/playstate/util.asm
+++ b/src/playstate/util.asm
@@ -80,6 +80,33 @@ updatePlayfield:
 updateMusicSpeed:
         ldx #$05
         lda multBy10Table,x ;this piece of code is parameterized for no reason but the crash checking code relies on the index being 50-59 so if you ever optimize this part out of the code please also adjust the crash test, specifically the part which handles cycles for allegro.
+
+; ignore crunch columns
+        ldy practiseType
+        cpy #MODE_CRUNCH
+        bne @notCrunch
+
+; count left columns and offset starting point (y)
+        lda crunchModifier
+        lsr
+        lsr
+        sta generalCounter ; to be combined with right column count
+        clc
+        adc multBy10Table,x
+        tay
+
+; add right crunch columns to left columns to get x value
+        lda crunchModifier
+        and #3
+        adc generalCounter ; carry is already clear from previous add
+        sta generalCounter
+        lda #$0A
+        sec
+        sbc generalCounter ; subtract total crunch columns
+        tax
+        bne @checkForBlockInRow ; unconditional
+
+@notCrunch:
         tay
         ldx #$0A
 @checkForBlockInRow:


### PR DESCRIPTION
Potential fix for #103 

The crunch columns were affecting the values of allegro & allegroIndex.  After modifying updateMusicSpeed to ignore the crunch columns, clearing singles below row 5 on level 157 with strict mode on would consistently crash.

@HydrantDude may want to take a look at this