### PR TITLE
Feature request:  faster method of selecting high levels

### DIFF
--- a/src/gamemode/levelmenu.asm
+++ b/src/gamemode/levelmenu.asm
@@ -241,6 +241,7 @@ highScoreClearUpOrLeave:
 @ret:
         rts
 
+levelModifier := generalCounter
 
 levelControlCustomLevel:
         jsr handleReadyInput
@@ -256,6 +257,14 @@ levelControlCustomLevel:
         jsr loadSpriteIntoOamStaging
 @indicatorEnd:
 
+; A pressed means a jump of 10 instead of 1
+        ldx #$01
+        lda heldButtons_player1
+        and #BUTTON_A
+        beq @aNotPressed
+        ldx #$0A
+@aNotPressed:
+        stx levelModifier
         ; lda #BUTTON_RIGHT
         ; jsr menuThrottle
         ; beq @checkUpPressed
@@ -268,13 +277,20 @@ levelControlCustomLevel:
         lda #BUTTON_UP
         jsr menuThrottle
         beq @checkDownPressed
-        inc customLevel
+        lda customLevel
+        clc
+        adc levelModifier
+        sta customLevel
+@skipIncrement:
         jsr @changeLevel
 @checkDownPressed:
         lda #BUTTON_DOWN
         jsr menuThrottle
         beq @checkLeftPressed
-        dec customLevel
+        lda customLevel
+        sec
+        sbc levelModifier
+        sta customLevel
         jsr @changeLevel
 @checkLeftPressed:
 

--- a/src/util/menuthrottle.asm
+++ b/src/util/menuthrottle.asm
@@ -1,11 +1,11 @@
 menuThrottle: ; add DAS-like movement to the menu
         sta menuThrottleTmp
         lda newlyPressedButtons_player1
-        cmp menuThrottleTmp
-        beq menuThrottleNew
+        and menuThrottleTmp
+        bne menuThrottleNew
         lda heldButtons_player1
-        cmp menuThrottleTmp
-        bne @endThrottle
+        and menuThrottleTmp
+        beq @endThrottle
         dec menuMoveThrottle
         beq menuThrottleContinue
 @endThrottle:


### PR DESCRIPTION
When testing the crunch mode crash, I thought it would be nice to choose higher levels a bit faster.  I had the idea of pressing right to add 10, but when going to add this feature to try it out I found there was precedent that was obviously not desired:  https://github.com/kirjavascript/TetrisGYM/blob/b499e7eb07df4da2c4d51679c2f8586af9f176eb/src/gamemode/levelmenu.asm#L259

Instead, I tried out holding A to jump by 10 instead of 1.  This required a slight modification to the menu throttle routine.  