### PR TITLE
update tspins test to look for 0x7e instead of 0x7b

### DIFF
--- a/tests/src/tspins.rs
+++ b/tests/src/tspins.rs
@@ -34,7 +34,7 @@ pub fn test() {
     "##.trim(), playfield::get_str(&emu).trim());
 
     // check that correct tile is rendered
-    assert_eq!(emu.ppu.read_byte(&mut *emu.mapper, 0x22CC), 0x7b);
+    assert_eq!(emu.ppu.read_byte(&mut *emu.mapper, 0x22CC), 0x7E);
     // check pixel is actually rendered
     assert_eq!(emu.ppu.screen[offset(96, 176) as usize], 0x30);
 }


### PR DESCRIPTION
The tiles used by the tspin function changed from 0x7b to 0x7e in cb895c47101236223e6ad0308a63f4b90b30962c and broke this test.  This fixes that.