### PR TITLE
optimized crunch with crash mode accommodated

### DIFF
--- a/src/modes/crunch.asm
+++ b/src/modes/crunch.asm
@@ -39,7 +39,6 @@ advanceSides:
 
     lda #BLOCK_TILES
 
-; y controls left tile count and offset into playfield
     ldy #$0
 @leftLoop:
     dec crunchLeftColumns
@@ -50,7 +49,6 @@ advanceSides:
 
 @initRight:
     ldy #$9
-; x controls right tile count, y controls offset into playfield
 @rightLoop:
     dec crunchRightColumns
     bmi crunchReturn
@@ -60,7 +58,6 @@ advanceSides:
 
 
 unpackCrunchModifier:
- ; initialize vars
     lda crunchModifier
     lsr
     lsr

--- a/src/modes/crunch.asm
+++ b/src/modes/crunch.asm
@@ -38,14 +38,14 @@ advanceGameCrunch:
     dec generalCounter
     bpl @nextRow
 
-; restore playfieldAddr and set vramRow for rendering
+; set vramRow to render entire playfield
     lda #$00
     sta vramRow
-    sta playfieldAddr
 crunchReturn:
     rts
 
 ; for init only.  row determined by generalCounter
+; playfieldAddr ends restored to 0 as top row is done last
 advanceSidesInit:
     ldy generalCounter
     lda multBy10Table,y

--- a/src/playstate/completedrows.asm
+++ b/src/playstate/completedrows.asm
@@ -1,5 +1,3 @@
-crunchLeftColumns := generalCounter3
-crunchClearColumns := generalCounter4
 activeFloorMode := generalCounter5
 
 playState_checkForCompletedRows:
@@ -146,7 +144,7 @@ playState_checkForCompletedRows:
         lda practiseType
         cmp #MODE_CRUNCH
         bne @crunchEnd
-        jsr advanceSides
+        jsr advanceSides ; clobbers generalCounter3 and generalCounter4
 @crunchEnd:
 
         lda completedLines

--- a/src/playstate/completedrows.asm
+++ b/src/playstate/completedrows.asm
@@ -144,7 +144,6 @@ playState_checkForCompletedRows:
         lda practiseType
         cmp #MODE_CRUNCH
         bne @crunchEnd
-        lda #1
         jsr advanceSides
 @crunchEnd:
 

--- a/src/playstate/completedrows.asm
+++ b/src/playstate/completedrows.asm
@@ -1,3 +1,5 @@
+crunchLeftColumns := generalCounter3
+crunchClearColumns := generalCounter4
 activeFloorMode := generalCounter5
 
 playState_checkForCompletedRows:

--- a/src/playstate/util.asm
+++ b/src/playstate/util.asm
@@ -83,12 +83,14 @@ updateMusicSpeed:
         tay
 
 ; check if crunch mode
-        lda practiseType
-        cmp #MODE_CRUNCH
+        ldx practiseType
+        cpx #MODE_CRUNCH
         bne @notCrunch
 
         ; start at first clear column and repeat only for playable columns
-        ldy crunchLeftColumns
+        clc
+        adc crunchLeftColumns ; accumulator is still 50, offset with left columns
+        tay
         ldx crunchClearColumns
         bne @checkForBlockInRow ; unconditional, expected range 4 - 10
 

--- a/src/playstate/util.asm
+++ b/src/playstate/util.asm
@@ -81,6 +81,18 @@ updateMusicSpeed:
         ldx #$05
         lda multBy10Table,x ;this piece of code is parameterized for no reason but the crash checking code relies on the index being 50-59 so if you ever optimize this part out of the code please also adjust the crash test, specifically the part which handles cycles for allegro.
         tay
+
+; check if crunch mode
+        lda practiseType
+        cmp #MODE_CRUNCH
+        bne @notCrunch
+
+        ; start at first clear column and repeat only for playable columns
+        ldy crunchLeftColumns
+        ldx crunchClearColumns
+        bne @checkForBlockInRow ; unconditional, expected range 4 - 10
+
+@notCrunch:
         ldx #$0A
 @checkForBlockInRow:
         lda (playfieldAddr),y

--- a/src/playstate/util.asm
+++ b/src/playstate/util.asm
@@ -77,23 +77,35 @@ updatePlayfield:
         sta vramRow
 @ret:   rts
 
+crunchLeftColumns = generalCounter3
+crunchRightColumns = generalCounter4
+
 updateMusicSpeed:
-        ldx #$05
-        lda multBy10Table,x ;this piece of code is parameterized for no reason but the crash checking code relies on the index being 50-59 so if you ever optimize this part out of the code please also adjust the crash test, specifically the part which handles cycles for allegro.
-        tay
+
+        ; ldx #$05
+        ; lda multBy10Table,x ;this piece of code is parameterized for no reason but the crash checking code relies on the index being 50-59 so if you ever optimize this part out of the code please also adjust the crash test, specifically the part which handles cycles for allegro.
+        ; tay
+
+        ldy #50 ; replaces above
 
 ; check if crunch mode
         ldx practiseType
         cpx #MODE_CRUNCH
         bne @notCrunch
 
-        ; start at first clear column and repeat only for playable columns
+        ; add crunch left columns to y
         jsr unpackCrunchModifier
         tya
         clc
         adc crunchLeftColumns ; offset y with left column count (generalCounter3)
         tay
-        ldx crunchClearColumns ; generalCounter4
+
+        ; set x to playable column count
+        lda #$0A
+        sec
+        sbc crunchLeftColumns ; generalCounter3
+        sbc crunchRightColumns ; generalCounter4
+        tax
         bne @checkForBlockInRow ; unconditional, expected range 4 - 10
 
 @notCrunch:

--- a/src/playstate/util.asm
+++ b/src/playstate/util.asm
@@ -88,10 +88,12 @@ updateMusicSpeed:
         bne @notCrunch
 
         ; start at first clear column and repeat only for playable columns
+        jsr unpackCrunchModifier
+        tya
         clc
-        adc crunchLeftColumns ; accumulator is still 50, offset with left columns
+        adc crunchLeftColumns ; offset y with left column count (generalCounter3)
         tay
-        ldx crunchClearColumns
+        ldx crunchClearColumns ; generalCounter4
         bne @checkForBlockInRow ; unconditional, expected range 4 - 10
 
 @notCrunch:

--- a/src/ram.asm
+++ b/src/ram.asm
@@ -220,10 +220,8 @@ dasOnlyShiftDisabled: .res 1 ; $63A
 invisibleFlag: .res 1 ; $63B  ; 0 for normal mode, non-zero for Invisible playfield rendering.  Reset on game init and game over.
 currentFloor: .res 1 ; $63C floorModifier is copied here at game init.  Set to 0 otherwise and incremented when linecap floor.
 mapperId: .res 1 ; $63D ; For INES_MAPPER 1000 (autodetect).  0 = CNROM.  1 = MMC1.
-crunchLeftColumns: .res 1
-crunchClearColumns: .res 1 ; playable column count
 
-    .res $35
+    .res $37
 
 .if KEYBOARD
 newlyPressedKeys: .res 1 ; $0675

--- a/src/ram.asm
+++ b/src/ram.asm
@@ -220,8 +220,10 @@ dasOnlyShiftDisabled: .res 1 ; $63A
 invisibleFlag: .res 1 ; $63B  ; 0 for normal mode, non-zero for Invisible playfield rendering.  Reset on game init and game over.
 currentFloor: .res 1 ; $63C floorModifier is copied here at game init.  Set to 0 otherwise and incremented when linecap floor.
 mapperId: .res 1 ; $63D ; For INES_MAPPER 1000 (autodetect).  0 = CNROM.  1 = MMC1.
+crunchLeftColumns: .res 1
+crunchClearColumns: .res 1 ; playable column count
 
-    .res $37
+    .res $35
 
 .if KEYBOARD
 newlyPressedKeys: .res 1 ; $0675


### PR DESCRIPTION
This should fix #103 and supersede #117

This uses 2 bytes of ram to store unpacked data derived from `crunchModifier` to speed up the column drawing function.  This also simplifies the modification of `checkMusicSpeed` so that the crunch columns don't interfere with allegro.  The additional bytes used in `checkMusicSpeed` were saved in the rewriting of crunch so there's no additional romspace used.

