### PR TITLE
set carry before subtract in floor

### DIFF
--- a/src/modes/floor.asm
+++ b/src/modes/floor.asm
@@ -4,6 +4,7 @@ drawFloor:
         ; get correct offset
         sta tmp1
         lda #$D
+        sec
         sbc tmp1
         tax
         ; x10


### PR DESCRIPTION
This subtract is currently relying on the carry being set by the cmp that occurs before branching