### PR TITLE
Fix topout sound

### DIFF
--- a/src/audio.asm
+++ b/src/audio.asm
@@ -144,6 +144,8 @@ advanceAudioSlotFrame:
 @ret:   rts
 
 .align $100
+        .byte $00 ; pad so low byte is not zero.  See tya in initSoundEffectShared
+
 ; Referenced by initSoundEffectShared
 soundEffectSlot0_gameOverCurtainInitData:
         .byte   $1F,$7F,$0F,$C0


### PR DESCRIPTION
Topout sound disappeared due to 3e541b0b8b52e3fbce7723be17b33099e2fd6e06.  Fixed by padding by one byte.   The low byte of the sound effect is loaded into the y register, a shared routine uses that being equal to zero as a condition to skip over the init routine.   


https://github.com/kirjavascript/TetrisGYM/blob/d81543a6c645aa22a7acbe219dcebadd88bdedca/src/audio.asm#L405-L409


https://github.com/kirjavascript/TetrisGYM/blob/d81543a6c645aa22a7acbe219dcebadd88bdedca/src/audio.asm#L338-L344