### PR TITLE
Clear crashState at game init

### DIFF
--- a/src/gamemodestate/initstate.asm
+++ b/src/gamemodestate/initstate.asm
@@ -46,6 +46,7 @@ gameModeState_initGameState:
         sta dasOnlyShiftDisabled
         sta invisibleFlag
         sta currentFloor
+        sta crashState
 
 ; initialize currentFloor if necessary
         lda practiseType


### PR DESCRIPTION
Noticed that after switching the crash mode to `SHOW` from `TOPOUT` after a crash, the next game would show a crash.    This doesn't happen when resetting crashState to 0 at game init.   