### PR TITLE
remove unneeded legacy tables

### DIFF
--- a/src/data/orientation.asm
+++ b/src/data/orientation.asm
@@ -30,12 +30,6 @@ orientationTable:
         .byte   $00,$00,$7B,$01,$00,$FF,$00,$00
         .byte   $FF,$00,$00,$FF,$00,$00,$FF,$00
 
-; Only cares about orientations selected by spawnTable
-orientationToSpriteTable:
-        .byte   $00,$00,$06,$00,$00,$00,$00,$09
-        .byte   $08,$00,$0B,$07,$00,$00,$0A,$00
-        .byte   $00,$00,$0C
-
 tetriminoTypeFromOrientation:
         .byte   $00,$00,$00,$00,$01,$01,$01,$01
         .byte   $02,$02,$03,$04,$04,$05,$05,$05
@@ -43,7 +37,3 @@ tetriminoTypeFromOrientation:
 spawnTable:
         .byte   $02,$07,$08,$0A,$0B,$0E,$12
         .byte   $02
-spawnOrientationFromOrientation:
-        .byte   $02,$02,$02,$02,$07,$07,$07,$07
-        .byte   $08,$08,$0A,$0B,$0B,$0E,$0E,$0E
-        .byte   $0E,$12,$12

--- a/src/playstate/spawnnext.asm
+++ b/src/playstate/spawnnext.asm
@@ -47,8 +47,7 @@ playState_spawnNextTetrimino:
         sta tetriminoY
         lda #$05
         sta tetriminoX
-        ldx nextPiece
-        lda spawnOrientationFromOrientation,x
+        lda nextPiece
         sta currentPiece
         jsr incrementPieceStat
         jsr chooseNextTetrimino

--- a/src/sprites/loadsprite.asm
+++ b/src/sprites/loadsprite.asm
@@ -51,11 +51,11 @@ oamContentLookup:
         .addr   sprite02Blank
         .addr   sprite02Blank
         .addr   sprite06TPiece
-        .addr   sprite07SPiece
+        .addr   sprite07JPiece
         .addr   sprite08ZPiece
-        .addr   sprite09JPiece
-        .addr   sprite0ALPiece
-        .addr   sprite0BOPiece
+        .addr   sprite09OPiece
+        .addr   sprite0ASPiece
+        .addr   sprite0BLPiece
         .addr   sprite0CIPiece
         .addr   sprite0EHighScoreNameCursor
         .addr   sprite0EHighScoreNameCursor
@@ -95,25 +95,25 @@ sprite06TPiece:
         .byte   $00,$7B,$02,$FC,$00,$7B,$02,$04
         .byte   $00,$7B,$02,$0C,$08,$7B,$02,$04
         .byte   $FF
-sprite07SPiece:
-        .byte   $00,$7D,$02,$04,$00,$7D,$02,$0C
-        .byte   $08,$7D,$02,$FC,$08,$7D,$02,$04
+sprite07JPiece:
+        .byte   $00,$7D,$02,$FC,$00,$7D,$02,$04
+        .byte   $00,$7D,$02,$0C,$08,$7D,$02,$0C
         .byte   $FF
 sprite08ZPiece:
         .byte   $00,$7C,$02,$FC,$00,$7C,$02,$04
         .byte   $08,$7C,$02,$04,$08,$7C,$02,$0C
         .byte   $FF
-sprite09JPiece:
-        .byte   $00,$7D,$02,$FC,$00,$7D,$02,$04
-        .byte   $00,$7D,$02,$0C,$08,$7D,$02,$0C
-        .byte   $FF
-sprite0ALPiece:
-        .byte   $00,$7C,$02,$FC,$00,$7C,$02,$04
-        .byte   $00,$7C,$02,$0C,$08,$7C,$02,$FC
-        .byte   $FF
-sprite0BOPiece:
+sprite09OPiece:
         .byte   $00,$7B,$02,$00,$00,$7B,$02,$08
         .byte   $08,$7B,$02,$00,$08,$7B,$02,$08
+        .byte   $FF
+sprite0ASPiece:
+        .byte   $00,$7D,$02,$04,$00,$7D,$02,$0C
+        .byte   $08,$7D,$02,$FC,$08,$7D,$02,$04
+        .byte   $FF
+sprite0BLPiece:
+        .byte   $00,$7C,$02,$FC,$00,$7C,$02,$04
+        .byte   $00,$7C,$02,$0C,$08,$7C,$02,$FC
         .byte   $FF
 sprite0CIPiece:
         .byte   $04,$7B,$02,$F8,$04,$7B,$02,$00

--- a/src/sprites/piece.asm
+++ b/src/sprites/piece.asm
@@ -145,7 +145,9 @@ stageSpriteForNextPiece:
         lda #$77
         sta spriteYOffset
         ldx nextPiece
-        lda orientationToSpriteTable,x
+        lda tetriminoTypeFromOrientation,x
+        clc
+        adc #$6 ; piece sprites start at index 6
         sta spriteIndexInOamContentLookup
         jmp loadSpriteIntoOamStaging
 


### PR DESCRIPTION
orientationToSpriteTable is used to map the spawnId to the arbitrary sprite ID for the next piece.  Reordering the sprites to match the game's piece ID order and reusing tetriminoTypeFromOrientation, this table can be removed.

spawnOrientationFromOrientation may have been created in development when the RNG produced the orientation ID instead of the piece ID, but random spawn orientations weren't desired.  As it's currently being used to convert the spawn ID to the same spawn ID, it can be removed.

Reduces PRG usage by 38 bytes