### PR TITLE
Add marathon modes 3 & 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fixed a glitch in Hard Drop Mode
 * Fixed line based floor caps outside of levelups
 * Reset scores when no SRAM is present
+* Add Marathon modes 3 & 4 where scoring scales normally
 
 ## v6
 * Crunch Trainer

--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ Play as long as you are able to survive at a consistent speed.
 0. Level transitions do not happen, game remains on the same level for as long as you are able to survive.
 1. Levels will transition normally, but speed and points will remain fixed based on your starting level.
 2. Similar to 1, speed and points will remain fixed based on the starting level you choose, but actual game will begin at level 0.
+3. Same as 1, but scoring scales normally
+4. Same as 2, but scoring scales normally
 
 ### Garbage
 

--- a/src/constants.asm
+++ b/src/constants.asm
@@ -144,7 +144,7 @@ MENU_TOP_MARGIN_SCROLL := 7 ; in blocks
     .byte $F    ; MODE_CRUNCH
     .byte $20   ; MODE_TAP
     .byte $10   ; MODE_TRANSITION
-    .byte $2    ; MODE_MARATHON
+    .byte $4    ; MODE_MARATHON
     .byte $1F   ; MODE_TAPQTY
     .byte $8    ; MODE_CHECKERBOARD
     .byte $4    ; MODE_GARBAGE

--- a/src/gamemode/levelmenu.asm
+++ b/src/gamemode/levelmenu.asm
@@ -133,8 +133,11 @@ levelMenuCheckStartGame:
         cpy #MODE_MARATHON
         bne @noLevelModification
         ldy marathonModifier
-        cpy #2 ; marathon mode 2 starts at level 0
+        cpy #2 ; marathon modes 2 & 4 starts at level 0
+        beq @startAtZero
+        cpy #4
         bne @noLevelModification
+@startAtZero:
         lda #0
 @noLevelModification:
         sta levelNumber

--- a/src/playstate/updatestats.asm
+++ b/src/playstate/updatestats.asm
@@ -349,6 +349,9 @@ addLineClearPoints:
         ldy practiseType
         cpy #MODE_MARATHON
         bne @notMarathon
+        ldy marathonModifier
+        cpy #3 ; Marathon modes 3 + 4 score normally
+        bcs @notMarathon
         lda startLevel
 @notMarathon:
         sta factorA24+0


### PR DESCRIPTION
Closes #137.  Adds marathon modes 3 & 4 that are like 1 & 2 except with scoring that matches the displayed level.  