### PR TITLE
remove 'feature force_range'

### DIFF
--- a/src/gamemode/gametypemenu/menu.asm
+++ b/src/gamemode/gametypemenu/menu.asm
@@ -537,7 +537,7 @@ menuYTmp := tmp2
         ldx darkModifier
         lda darkOptions, x
         sta spriteIndexInOamContentLookup
-        lda #(MODE_DARK*8) + MENU_SPRITE_Y_BASE + 1
+        lda #<((MODE_DARK*8) + MENU_SPRITE_Y_BASE + 1)
 
 @renderOption:
         sec

--- a/src/main.asm
+++ b/src/main.asm
@@ -12,7 +12,6 @@
 .include "chr.asm"
 
 .setcpu "6502"
-.feature force_range
 
 .segment    "PRG_chunk1": absolute
 

--- a/src/nmi/render_mode_pause.asm
+++ b/src/nmi/render_mode_pause.asm
@@ -4,7 +4,7 @@ render_mode_pause:
         beq @skipSaveSlotPatch
         jsr saveSlotNametablePatch
         lda renderFlags
-        and #~RENDER_DEBUG
+        and #<~RENDER_DEBUG
         sta renderFlags
 @skipSaveSlotPatch:
         lda playState

--- a/src/nmi/render_mode_play_and_demo.asm
+++ b/src/nmi/render_mode_play_and_demo.asm
@@ -40,7 +40,7 @@ render_mode_play_and_demo:
         jsr renderModernLines
 @doneRenderingLines:
         lda renderFlags
-        and #~RENDER_LINES
+        and #<~RENDER_LINES
         sta renderFlags
 
 @renderLevel:
@@ -85,7 +85,7 @@ render_mode_play_and_demo:
 @renderLevelEnd:
         jsr updatePaletteForLevel
         lda renderFlags
-        and #~RENDER_LEVEL
+        and #<~RENDER_LEVEL
         sta renderFlags
 
 @renderScore:
@@ -164,7 +164,7 @@ render_mode_play_and_demo:
 
 @clearScoreRenderFlags:
         lda renderFlags
-        and #~RENDER_SCORE
+        and #<~RENDER_SCORE
         sta renderFlags
 
 @renderHz:
@@ -175,7 +175,7 @@ render_mode_play_and_demo:
         beq @renderStatsHz
         jsr renderHz
         lda renderFlags
-        and #~RENDER_HZ
+        and #<~RENDER_HZ
         sta renderFlags
 
         ; run a patched version of the stats
@@ -207,7 +207,7 @@ render_mode_play_and_demo:
         lda statsByType,x
         jsr twoDigsToPPU
         lda renderFlags
-        and #~RENDER_STATS
+        and #<~RENDER_STATS
         sta renderFlags
 @renderTetrisFlashAndSound:
         lda #$3F


### PR DESCRIPTION
https://github.com/kirjavascript/TetrisGYM/blob/2ba3d20f73ffd27de254f09733297dfbfac6e359/src/util/strings.asm#L72

When messing around with these strings I realized the feature force_range could cause problems here (and probably other places) that wouldn't be immediately apparent.  It was only added for a cleaner looking syntax.  Removing.  