### PR TITLE
use direct label for crash code

### DIFF
--- a/src/modes/crash.asm
+++ b/src/modes/crash.asm
@@ -221,7 +221,7 @@ testCrash:
         inc allegroIndex
 @newBit0:
         lda nmiReturnAddr
-        cmp #<updateAudioWaitForNmiAndResetOamStaging+10
+        cmp #<nmiLoopMidpoint
         beq @returnLate ; checking which instruction returned to. if so, add 3 cycles
         lda #$03
         clc

--- a/src/util/core.asm
+++ b/src/util/core.asm
@@ -61,9 +61,12 @@ updateAudioWaitForNmiAndResetOamStaging:
         lda #$00
         sta verticalBlankingInterval
         nop
-@checkForNmi:
+
+checkForNmi:
         lda verticalBlankingInterval
-        beq @checkForNmi
+; label used for crash code to determine if nmi happened here or at the previous instruction
+nmiLoopMidpoint:
+        beq checkForNmi
 
 .if KEYBOARD = 1
 ; Read Family BASIC Keyboard


### PR DESCRIPTION
this helps prevent assembler issues due to shifting code or inaccuracy issues if the wait code is modified. 

@HydrantDude FYI