### PR TITLE
use currentPpuCtrl as basis to enable vertical drawing

### DIFF
--- a/src/nmi/render_input_log.asm
+++ b/src/nmi/render_input_log.asm
@@ -30,11 +30,6 @@ renderHzInputRows:
         lda #2
         sta inputLogCounter
 
-        ; enable vertical drawing
-        lda PPUCTRL
-        ora #%100
-        sta PPUCTRL
-
         jsr getInputAddr
         tya
         sta PPUADDR
@@ -51,10 +46,6 @@ renderHzInputRows:
         sta PPUADDR
 
         jsr clearInputLine
-
-        lda PPUCTRL
-        and #%11111011
-        sta PPUCTRL
 
 
 @checkLimit:

--- a/src/nmi/render_input_log.asm
+++ b/src/nmi/render_input_log.asm
@@ -30,6 +30,11 @@ renderHzInputRows:
         lda #2
         sta inputLogCounter
 
+        ; enable vertical drawing
+        lda currentPpuCtrl
+        ora #%100
+        sta PPUCTRL
+
         jsr getInputAddr
         tya
         sta PPUADDR
@@ -46,6 +51,9 @@ renderHzInputRows:
         sta PPUADDR
 
         jsr clearInputLine
+
+        lda currentPpuCtrl
+        sta PPUCTRL
 
 
 @checkLimit:
@@ -85,8 +93,11 @@ renderHzInputRows:
         rts
 
 clearInputLine:
+        lda #28
+        sec
+        sbc inputLogCounter
+        tax
         lda #$FF
-        ldx #26
 @clearRow:
         sta PPUDATA
         dex


### PR DESCRIPTION
ppuctrl doesn't provide useful data when read, and as a result the [PPU master/slave select](https://www.nesdev.org/wiki/PPU_registers#Master/slave_mode_and_the_EXT_pins) bit was getting set in mesen, triggering a breakpoint.  Normally the fix would be to read from currentPpuCtrl instead, but in this case the vertical drawing feature isn't needed.  